### PR TITLE
Fix for incompatibility between interrupt VGA modes and SPIFFS/WIFI

### DIFF
--- a/src/I2S/I2S.cpp
+++ b/src/I2S/I2S.cpp
@@ -32,8 +32,21 @@ I2S::I2S(const int i2sIndex)
 void IRAM_ATTR I2S::interruptStatic(void *arg)
 {
 	volatile i2s_dev_t &i2s = *i2sDevices[((I2S *)arg)->i2sIndex];
-	i2s.int_clr.val = i2s.int_raw.val;
-	((I2S *)arg)->interrupt();
+	//i2s object not safely accesed in DRAM or IRAM
+	//i2s.int_clr.val = i2s.int_raw.val;
+	//using REG_WRITE to clear the interrupt instead
+	//note: there are still other alternatives, see i2s driver .c file
+	//inside the i2s_intr_handler_default() function
+	REG_WRITE(I2S_INT_CLR_REG(((I2S *)arg)->i2sIndex), (REG_READ(I2S_INT_RAW_REG(((I2S *)arg)->i2sIndex)) & 0xffffffc0) | 0x3f);
+	//the call to the overloaded (or any) non-static member function definitely breaks the IRAM rule
+	// causing an exception when concurrently accessing the flash (or flash-filesystem) or wifi
+	//the reason is unknown but probably related with the compiler instantiation mechanism
+	//(note: defining the code of the [member] interrupt function outside the class declaration,
+	// and with IRAM flag does not avoid the crash)
+	//((I2S *)arg)->interrupt();
+	
+	if(((I2S *)arg)->interruptStaticChild)
+		((I2S *)arg)->interruptStaticChild(arg);
 }
 
 void I2S::reset()

--- a/src/I2S/I2S.h
+++ b/src/I2S/I2S.h
@@ -52,8 +52,9 @@ class I2S
 	void allocateDMABuffers(int count, int bytes);
 	void deleteDMABuffers();
 
+	void (*interruptStaticChild)(void *arg) = 0;
+
   protected:
-	virtual void interrupt() = 0;
 	virtual bool useInterrupt();
 	void setAPLLClock(long sampleRate, int bitCount);
 	void setClock(long sampleRate, int bitCount, bool useAPLL = true);

--- a/src/VGA/VGA3BitI.h
+++ b/src/VGA/VGA3BitI.h
@@ -19,6 +19,7 @@ class VGA3BitI : public VGA, public GraphicsR1G1B1A1
 	VGA3BitI()	//8 bit based modes only work with I2S1
 		: VGA(1)
 	{
+		interruptStaticChild = &VGA3BitI::interrupt;
 	}
 
 	bool init(const Mode &mode, const int RPin, const int GPin, const int BPin, const int hsyncPin, const int vsyncPin, const int clockPin = -1)
@@ -29,7 +30,7 @@ class VGA3BitI : public VGA, public GraphicsR1G1B1A1
 			BPin,
 			-1, -1, -1,
 			hsyncPin, vsyncPin
-		};	
+		};
 		return VGA::init(mode, pinMap, 8, clockPin);
 	}
 
@@ -87,53 +88,61 @@ class VGA3BitI : public VGA, public GraphicsR1G1B1A1
 		return true; 
 	};
 
-	void interrupt()
-	{
-		unsigned long *signal = (unsigned long *)dmaBufferDescriptors[dmaBufferDescriptorActive].buffer();
-		unsigned long *pixels = &((unsigned long *)dmaBufferDescriptors[dmaBufferDescriptorActive].buffer())[(mode.hSync + mode.hBack) / 4];
-		unsigned long base, baseh;
-		if (currentLine >= mode.vFront && currentLine < mode.vFront + mode.vSync)
-		{
-			baseh = syncBits(true, true);
-			base = syncBits(false, true);
-		}
-		else
-		{
-			baseh = syncBits(true, false);
-			base =  syncBits(false, false);
-		}
-		for (int i = 0; i < mode.hSync / 4; i++)
-			signal[i] = baseh;
-		for (int i = mode.hSync / 4; i < (mode.hSync + mode.hBack) / 4; i++)
-			signal[i] = base;
+	static void interrupt(void *arg);
 
-		int y = (currentLine - mode.vFront - mode.vSync - mode.vBack) / mode.vDiv;
-		if (y >= 0 && y < mode.vRes)
-			interruptPixelLine(y, pixels, base);
-		else
-			for (int i = 0; i < mode.hRes / 4; i++)
-			{
-				pixels[i] = base;
-			}
-		for (int i = 0; i < mode.hFront / 4; i++)
-			signal[i + (mode.hSync + mode.hBack + mode.hRes) / 4] = base;
-		currentLine = (currentLine + 1) % totalLines;
-		dmaBufferDescriptorActive = (dmaBufferDescriptorActive + 1) % dmaBufferDescriptorCount;
-		if (currentLine == 0)
-			vSync();
-	}
-
-	void interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits)
-	{
-		unsigned char *line = frontBuffer[y];
-		int j = 0;
-		for (int i = 0; i < mode.hRes / 4; i++)
-		{
-			int p0 = (line[j] >> 0) & 7;
-			int p1 = (line[j++] >> 4) & 7;
-			int p2 = (line[j] >> 0) & 7;
-			int p3 = (line[j++] >> 4) & 7;
-			pixels[i] = syncBits | (p2 << 0) | (p3 << 8) | (p0 << 16) | (p1 << 24);
-		}
-	}
+	static void interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg);
 };
+
+
+void IRAM_ATTR VGA3BitI::interrupt(void *arg)
+{
+	VGA3BitI * staticthis = (VGA3BitI *)arg;
+	
+	unsigned long *signal = (unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer();
+	unsigned long *pixels = &((unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer())[(staticthis->mode.hSync + staticthis->mode.hBack) / 4];
+	unsigned long base, baseh;
+	if (staticthis->currentLine >= staticthis->mode.vFront && staticthis->currentLine < staticthis->mode.vFront + staticthis->mode.vSync)
+	{
+		baseh = (staticthis->hsyncBit | staticthis->vsyncBit) * 0x1010101;
+		base = (staticthis->hsyncBitI | staticthis->vsyncBit) * 0x1010101;
+	}
+	else
+	{
+		baseh = (staticthis->hsyncBit | staticthis->vsyncBitI) * 0x1010101;
+		base = (staticthis->hsyncBitI | staticthis->vsyncBitI) * 0x1010101;
+	}
+	for (int i = 0; i < staticthis->mode.hSync / 4; i++)
+		signal[i] = baseh;
+	for (int i = staticthis->mode.hSync / 4; i < (staticthis->mode.hSync + staticthis->mode.hBack) / 4; i++)
+		signal[i] = base;
+
+	int y = (staticthis->currentLine - staticthis->mode.vFront - staticthis->mode.vSync - staticthis->mode.vBack) / staticthis->mode.vDiv;
+	if (y >= 0 && y < staticthis->mode.vRes)
+		staticthis->interruptPixelLine(y, pixels, base, arg);
+	else
+		for (int i = 0; i < staticthis->mode.hRes / 4; i++)
+		{
+			pixels[i] = base;
+		}
+	for (int i = 0; i < staticthis->mode.hFront / 4; i++)
+		signal[i + (staticthis->mode.hSync + staticthis->mode.hBack + staticthis->mode.hRes) / 4] = base;
+	staticthis->currentLine = (staticthis->currentLine + 1) % staticthis->totalLines;
+	staticthis->dmaBufferDescriptorActive = (staticthis->dmaBufferDescriptorActive + 1) % staticthis->dmaBufferDescriptorCount;
+	if (staticthis->currentLine == 0)
+		staticthis->vSyncPassed = true;
+}
+
+void IRAM_ATTR VGA3BitI::interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg)
+{
+	VGA3BitI * staticthis = (VGA3BitI *)arg;
+	unsigned char *line = staticthis->frontBuffer[y];
+	int j = 0;
+	for (int i = 0; i < staticthis->mode.hRes / 4; i++)
+	{
+		int p0 = (line[j] >> 0) & 7;
+		int p1 = (line[j++] >> 4) & 7;
+		int p2 = (line[j] >> 0) & 7;
+		int p3 = (line[j++] >> 4) & 7;
+		pixels[i] = syncBits | (p2 << 0) | (p3 << 8) | (p0 << 16) | (p1 << 24);
+	}
+}

--- a/src/VGA/VGA6BitI.h
+++ b/src/VGA/VGA6BitI.h
@@ -19,9 +19,10 @@ class VGA6BitI : public VGA, public GraphicsR2G2B2A2
 	VGA6BitI()	//8 bit based modes only work with I2S1
 		: VGA(1)
 	{
+		interruptStaticChild = &VGA6BitI::interrupt;
 	}
 
-	bool init(Mode &mode,
+	bool init(const Mode &mode,
 			  const int R0Pin, const int R1Pin,
 			  const int G0Pin, const int G1Pin,
 			  const int B0Pin, const int B1Pin,
@@ -33,7 +34,6 @@ class VGA6BitI : public VGA, public GraphicsR2G2B2A2
 			B0Pin, B1Pin,
 			hsyncPin, vsyncPin
 		};
-
 		return VGA::init(mode, pinMap, 8, clockPin);
 	}
 
@@ -47,8 +47,7 @@ class VGA6BitI : public VGA, public GraphicsR2G2B2A2
 			pinMap[i + 4] = bluePins[i];
 		}
 		pinMap[6] = hsyncPin;
-		pinMap[7] = vsyncPin;			
-		return VGA::init(mode, pinMap, 8, clockPin);
+		pinMap[7] = vsyncPin;			return VGA::init(mode, pinMap, 8, clockPin);
 	}
 
 	bool init(const Mode &mode, const PinConfig &pinConfig)
@@ -105,53 +104,61 @@ class VGA6BitI : public VGA, public GraphicsR2G2B2A2
 		return true; 
 	};
 
-	void interrupt()
-	{
-		unsigned long *signal = (unsigned long *)dmaBufferDescriptors[dmaBufferDescriptorActive].buffer();
-		unsigned long *pixels = &((unsigned long *)dmaBufferDescriptors[dmaBufferDescriptorActive].buffer())[(mode.hSync + mode.hBack) / 4];
-		unsigned long base, baseh;
-		if (currentLine >= mode.vFront && currentLine < mode.vFront + mode.vSync)
-		{
-			baseh = syncBits(true, true);
-			base = syncBits(false, true);
-		}
-		else
-		{
-			baseh = syncBits(true, false);
-			base =  syncBits(false, false);
-		}
-		for (int i = 0; i < mode.hSync / 4; i++)
-			signal[i] = baseh;
-		for (int i = mode.hSync / 4; i < (mode.hSync + mode.hBack) / 4; i++)
-			signal[i] = base;
+	static void interrupt(void *arg);
 
-		int y = (currentLine - mode.vFront - mode.vSync - mode.vBack) / mode.vDiv;
-		if (y >= 0 && y < mode.vRes)
-			interruptPixelLine(y, pixels, base);
-		else
-			for (int i = 0; i < mode.hRes / 4; i++)
-			{
-				pixels[i] = base;
-			}
-		for (int i = 0; i < mode.hFront / 4; i++)
-			signal[i + (mode.hSync + mode.hBack + mode.hRes) / 4] = base;
-		currentLine = (currentLine + 1) % totalLines;
-		dmaBufferDescriptorActive = (dmaBufferDescriptorActive + 1) % dmaBufferDescriptorCount;
-		if (currentLine == 0)
-			vSync();
-	}
-
-	void interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits)
-	{
-		unsigned char *line = frontBuffer[y];
-		int j = 0;
-		for (int i = 0; i < mode.hRes / 4; i++)
-		{
-			int p0 = (line[j] >> 0) & 7;
-			int p1 = (line[j++] >> 4) & 7;
-			int p2 = (line[j] >> 0) & 7;
-			int p3 = (line[j++] >> 4) & 7;
-			pixels[i] = syncBits | (p2 << 0) | (p3 << 8) | (p0 << 16) | (p1 << 24);
-		}
-	}
+	static void interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg);
 };
+
+
+void IRAM_ATTR VGA6BitI::interrupt(void *arg)
+{
+	VGA6BitI * staticthis = (VGA6BitI *)arg;
+	
+	unsigned long *signal = (unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer();
+	unsigned long *pixels = &((unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer())[(staticthis->mode.hSync + staticthis->mode.hBack) / 4];
+	unsigned long base, baseh;
+	if (staticthis->currentLine >= staticthis->mode.vFront && staticthis->currentLine < staticthis->mode.vFront + staticthis->mode.vSync)
+	{
+		baseh = (staticthis->hsyncBit | staticthis->vsyncBit) * 0x1010101;
+		base = (staticthis->hsyncBitI | staticthis->vsyncBit) * 0x1010101;
+	}
+	else
+	{
+		baseh = (staticthis->hsyncBit | staticthis->vsyncBitI) * 0x1010101;
+		base = (staticthis->hsyncBitI | staticthis->vsyncBitI) * 0x1010101;
+	}
+	for (int i = 0; i < staticthis->mode.hSync / 4; i++)
+		signal[i] = baseh;
+	for (int i = staticthis->mode.hSync / 4; i < (staticthis->mode.hSync + staticthis->mode.hBack) / 4; i++)
+		signal[i] = base;
+
+	int y = (staticthis->currentLine - staticthis->mode.vFront - staticthis->mode.vSync - staticthis->mode.vBack) / staticthis->mode.vDiv;
+	if (y >= 0 && y < staticthis->mode.vRes)
+		staticthis->interruptPixelLine(y, pixels, base, arg);
+	else
+		for (int i = 0; i < staticthis->mode.hRes / 4; i++)
+		{
+			pixels[i] = base;
+		}
+	for (int i = 0; i < staticthis->mode.hFront / 4; i++)
+		signal[i + (staticthis->mode.hSync + staticthis->mode.hBack + staticthis->mode.hRes) / 4] = base;
+	staticthis->currentLine = (staticthis->currentLine + 1) % staticthis->totalLines;
+	staticthis->dmaBufferDescriptorActive = (staticthis->dmaBufferDescriptorActive + 1) % staticthis->dmaBufferDescriptorCount;
+	if (staticthis->currentLine == 0)
+		staticthis->vSyncPassed = true;
+}
+
+void IRAM_ATTR VGA6BitI::interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg)
+{
+	VGA6BitI * staticthis = (VGA6BitI *)arg;
+	unsigned char *line = staticthis->frontBuffer[y];
+	int j = 0;
+	for (int i = 0; i < staticthis->mode.hRes / 4; i++)
+	{
+		int p0 = (line[j++]) & 63;
+		int p1 = (line[j++]) & 63;
+		int p2 = (line[j++]) & 63;
+		int p3 = (line[j++]) & 63;
+		pixels[i] = syncBits | (p2 << 0) | (p3 << 8) | (p0 << 16) | (p1 << 24);
+	}
+}


### PR DESCRIPTION
Fixes interrupt clearance.
Interrupt() call to child replaced by pointer to a static function with instance as argument.
IRAM flag in routines.
Also fixes an error in rendering in VGA6BitI.
Fixes #31 