### PR TITLE
Fix for stability of VGA modes during SPIFFS/WIFI activity

### DIFF
--- a/examples/VGANoFrameBuffer/VGANoFrameBuffer.ino
+++ b/examples/VGANoFrameBuffer/VGANoFrameBuffer.ino
@@ -21,29 +21,69 @@ long frameNumber = 0;
 //Our own VGA Device
 class MyVGA : public VGA14BitI
 {
-  protected:
+	public:
+	//override this routine that is called during init to link the custom interrupt
+	void propagateResolution(const int xres, const int yres)
+	{
+		setResolution(xres, yres);
+		interruptStaticChild = &MyVGA::custominterrupt;
+	}
+	protected:
 	//override frame buffer allocation
 	virtual Color **allocateFrameBuffer()
 	{
 		return 0;
 	}
+	static void custominterrupt(void *arg);
+	static void custominterruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg);
+};
 
-	//override the sync callback to count the frames
-	virtual void vSync()
+//custominterrupt just copied from VGA14Bit except the initial and end lines
+void IRAM_ATTR MyVGA::custominterrupt(void *arg)
+{
+	MyVGA * staticthis = (MyVGA *)arg;
+//Modified for MyVGA until here
+
+	//fix for skipped lines due to skipped interupts during wifi activity
+	DMABufferDescriptor *currentDmaBufferDescriptor = (DMABufferDescriptor *)REG_READ(I2S_OUT_EOF_DES_ADDR_REG(staticthis->i2sIndex));
+	staticthis->dmaBufferDescriptorActive = ((uint32_t)currentDmaBufferDescriptor - (uint32_t)staticthis->dmaBufferDescriptors)/sizeof(DMABufferDescriptor);
+	staticthis->currentLine = staticthis->dmaBufferDescriptorActive; //equivalent in this configuration
+
+	int vInactiveLinesCount = staticthis->mode.vFront + staticthis->mode.vSync + staticthis->mode.vBack;
+
+	//render ahead (the lenght of buffered lines)
+	int renderLine = (staticthis->currentLine + staticthis->lineBufferCount) % staticthis->totalLines;
+
+	if (renderLine >= vInactiveLinesCount)
 	{
+		int renderActiveLine = renderLine - vInactiveLinesCount;
+		unsigned long *pixels = &((unsigned long *)staticthis->vActiveLineBuffer[renderActiveLine % staticthis->lineBufferCount])[(staticthis->mode.hSync + staticthis->mode.hBack) / 2];
+		unsigned long base = (staticthis->hsyncBitI | staticthis->vsyncBitI) * 0x10001;
+
+		int y = renderActiveLine / staticthis->mode.vDiv;
+		if (y >= 0 && y < staticthis->mode.vRes)
+//Modified for MyVGA from here
+		staticthis->custominterruptPixelLine(y, pixels, base, arg);
+	}
+
+	if (renderLine == 0)
+	{
+		staticthis->vSyncPassed = true;
+		//added to count the frames
 		frameNumber++;
 	}
+}
 
-	//draw each line
-	void interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits)
+//Custom rendering routine to draw each line
+void IRAM_ATTR MyVGA::custominterruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg)
+{
+	MyVGA * staticthis = (MyVGA *)arg;
+	for (int x = 0; x < staticthis->mode.hRes / 2; x++)
 	{
-		for (int x = 0; x < mode.hRes / 2; x++)
-		{
-			//writing two pixels improves speed drastically (avoids memory reads)
-			pixels[x] = syncBits | rainbow[(x - y + frameNumber) & 255];
-		}
+		//writing two pixels improves speed drastically (avoids memory reads)
+		pixels[x] = syncBits | rainbow[(x - y + frameNumber) & 255];
 	}
-};
+}
 
 //get an instance
 MyVGA vga;

--- a/src/I2S/I2S.cpp
+++ b/src/I2S/I2S.cpp
@@ -32,8 +32,21 @@ I2S::I2S(const int i2sIndex)
 void IRAM_ATTR I2S::interruptStatic(void *arg)
 {
 	volatile i2s_dev_t &i2s = *i2sDevices[((I2S *)arg)->i2sIndex];
-	i2s.int_clr.val = i2s.int_raw.val;
-	((I2S *)arg)->interrupt();
+	//i2s object not safely accesed in DRAM or IRAM
+	//i2s.int_clr.val = i2s.int_raw.val;
+	//using REG_WRITE to clear the interrupt instead
+	//note: there are still other alternatives, see i2s driver .c file
+	//inside the i2s_intr_handler_default() function
+	REG_WRITE(I2S_INT_CLR_REG(((I2S *)arg)->i2sIndex), (REG_READ(I2S_INT_RAW_REG(((I2S *)arg)->i2sIndex)) & 0xffffffc0) | 0x3f);
+	//the call to the overloaded (or any) non-static member function definitely breaks the IRAM rule
+	// causing an exception when concurrently accessing the flash (or flash-filesystem) or wifi
+	//the reason is unknown but probably related with the compiler instantiation mechanism
+	//(note: defining the code of the [member] interrupt function outside the class declaration,
+	// and with IRAM flag does not avoid the crash)
+	//((I2S *)arg)->interrupt();
+	
+	if(((I2S *)arg)->interruptStaticChild)
+		((I2S *)arg)->interruptStaticChild(arg);
 }
 
 void I2S::reset()

--- a/src/I2S/I2S.h
+++ b/src/I2S/I2S.h
@@ -52,8 +52,9 @@ class I2S
 	void allocateDMABuffers(int count, int bytes);
 	void deleteDMABuffers();
 
+	void (*interruptStaticChild)(void *arg) = 0;
+
   protected:
-	virtual void interrupt() = 0;
 	virtual bool useInterrupt();
 	void setAPLLClock(long sampleRate, int bitCount);
 	void setClock(long sampleRate, int bitCount, bool useAPLL = true);

--- a/src/VGA/VGA14BitI.h
+++ b/src/VGA/VGA14BitI.h
@@ -19,6 +19,7 @@ class VGA14BitI : public VGA, public GraphicsR5G5B4A2
 	VGA14BitI(const int i2sIndex = 1)
 		: VGA(i2sIndex)
 	{
+		lineBufferCount = 3;
 		interruptStaticChild = &VGA14BitI::interrupt;
 	}
 
@@ -87,6 +88,83 @@ class VGA14BitI : public VGA, public GraphicsR5G5B4A2
 		setResolution(xres, yres);
 	}
 
+	void *vBlankLineBuffer;
+	void *vSyncLineBuffer;
+	void **vActiveLineBuffer;
+
+	//complete ring of buffer descriptors for one frame
+	//actual linebuffers only for some lines rendered ahead
+	virtual void allocateLineBuffers()
+	{
+		//lenght of each line
+		int samples = mode.hFront + mode.hSync + mode.hBack + mode.hRes;
+		int bytes = samples * bytesPerSample();
+
+		//create and fill the buffers with their default values
+
+		//create the buffers
+		//1 blank prototype line for vFront and vBack
+		vBlankLineBuffer = DMABufferDescriptor::allocateBuffer(bytes, true);
+		//1 sync prototype line for vSync
+		vSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytes, true);
+		//n lines as buffer for active lines
+		int ActiveLinesBufferCount = lineBufferCount;
+		vActiveLineBuffer = (void **)malloc(ActiveLinesBufferCount * sizeof(void *));
+		if(!vActiveLineBuffer)
+			ERROR("Not enough memory for ActiveLineBuffer buffer");
+		for (int i = 0; i < ActiveLinesBufferCount; i++)
+		{
+			vActiveLineBuffer[i] = DMABufferDescriptor::allocateBuffer(bytes, true);
+		}
+
+		//fill the buffers with their default values
+		//(bytesPerSample() == 2)
+		for (int i = 0; i < samples; i++)
+		{
+			if (i < mode.hSync)
+			{
+				((unsigned short *)vSyncLineBuffer)[i ^ 1] = hsyncBit | vsyncBit;
+				((unsigned short *)vBlankLineBuffer)[i ^ 1] = hsyncBit | vsyncBitI;
+			}
+			else
+			{
+				((unsigned short *)vSyncLineBuffer)[i ^ 1] = hsyncBitI | vsyncBit;
+				((unsigned short *)vBlankLineBuffer)[i ^ 1] = hsyncBitI | vsyncBitI;
+			}
+		}
+		for (int i = 0; i < ActiveLinesBufferCount; i++)
+		{
+			memcpy(vActiveLineBuffer[i], vBlankLineBuffer, bytes);
+		}
+
+		//allocate DMA buffer descriptors for the whole frame
+		dmaBufferDescriptorCount = totalLines;
+		dmaBufferDescriptors = DMABufferDescriptor::allocateDescriptors(dmaBufferDescriptorCount);
+		//link all buffer descriptors in a ring
+		for (int i = 0; i < dmaBufferDescriptorCount; i++)
+			dmaBufferDescriptors[i].next(dmaBufferDescriptors[(i + 1) % dmaBufferDescriptorCount]);
+
+		//assign the buffers accross the DMA buffer descriptors
+		//CONVENTION: the frame starts after the last active line of previous frame
+		int d = 0;
+		for (int i = 0; i < mode.vFront; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vBlankLineBuffer, bytes);
+		}
+		for (int i = 0; i < mode.vSync; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vSyncLineBuffer, bytes);
+		}
+		for (int i = 0; i < mode.vBack; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vBlankLineBuffer, bytes);
+		}
+		for (int i = 0; i < mode.vRes; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vActiveLineBuffer[i % ActiveLinesBufferCount], bytes);
+		}
+	}
+
 	virtual void show(bool vSync = false)
 	{
 		if (!frameBufferCount)
@@ -115,39 +193,34 @@ class VGA14BitI : public VGA, public GraphicsR5G5B4A2
 void IRAM_ATTR VGA14BitI::interrupt(void *arg)
 {
 	VGA14BitI * staticthis = (VGA14BitI *)arg;
-	
-	unsigned long *signal = (unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer();
-	unsigned long *pixels = &((unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer())[(staticthis->mode.hSync + staticthis->mode.hBack) / 2];
-	unsigned long base, baseh;
-	if (staticthis->currentLine >= staticthis->mode.vFront && staticthis->currentLine < staticthis->mode.vFront + staticthis->mode.vSync)
-	{
-		baseh = (staticthis->hsyncBit | staticthis->vsyncBit) * 0x10001;
-		base = (staticthis->hsyncBitI | staticthis->vsyncBit) * 0x10001;
-	}
-	else
-	{
-		baseh = (staticthis->hsyncBit | staticthis->vsyncBitI) * 0x10001;
-		base = (staticthis->hsyncBitI | staticthis->vsyncBitI) * 0x10001;
-	}
-	for (int i = 0; i < staticthis->mode.hSync / 2; i++)
-		signal[i] = baseh;
-	for (int i = staticthis->mode.hSync / 2; i < (staticthis->mode.hSync + staticthis->mode.hBack) / 2; i++)
-		signal[i] = base;
 
-	int y = (staticthis->currentLine - staticthis->mode.vFront - staticthis->mode.vSync - staticthis->mode.vBack) / staticthis->mode.vDiv;
-	if (y >= 0 && y < staticthis->mode.vRes)
-		staticthis->interruptPixelLine(y, pixels, base, arg);
-	else
-		for (int i = 0; i < staticthis->mode.hRes / 2; i++)
-		{
-			pixels[i] = base | (base << 16);
-		}
-	for (int i = 0; i < staticthis->mode.hFront / 2; i++)
-		signal[i + (staticthis->mode.hSync + staticthis->mode.hBack + staticthis->mode.hRes) / 2] = base;
-	staticthis->currentLine = (staticthis->currentLine + 1) % staticthis->totalLines;
-	staticthis->dmaBufferDescriptorActive = (staticthis->dmaBufferDescriptorActive + 1) % staticthis->dmaBufferDescriptorCount;
-	if (staticthis->currentLine == 0)
+	//fix for skipped lines due to skipped interupts during wifi activity
+	DMABufferDescriptor *currentDmaBufferDescriptor = (DMABufferDescriptor *)REG_READ(I2S_OUT_EOF_DES_ADDR_REG(staticthis->i2sIndex));
+	staticthis->dmaBufferDescriptorActive = ((uint32_t)currentDmaBufferDescriptor - (uint32_t)staticthis->dmaBufferDescriptors)/sizeof(DMABufferDescriptor);
+	staticthis->currentLine = staticthis->dmaBufferDescriptorActive; //equivalent in this configuration
+	
+	int vInactiveLinesCount = staticthis->mode.vFront + staticthis->mode.vSync + staticthis->mode.vBack;
+	
+	//render ahead (the lenght of buffered lines)
+	int renderLine = (staticthis->currentLine + staticthis->lineBufferCount) % staticthis->totalLines;
+	
+	if (renderLine >= vInactiveLinesCount)
+	{
+		int renderActiveLine = renderLine - vInactiveLinesCount;
+		unsigned long *pixels = &((unsigned long *)staticthis->vActiveLineBuffer[renderActiveLine % staticthis->lineBufferCount])[(staticthis->mode.hSync + staticthis->mode.hBack) / 2];
+		unsigned long base = (staticthis->hsyncBitI | staticthis->vsyncBitI) * 0x10001;
+
+		int y = renderActiveLine / staticthis->mode.vDiv;
+		if (y >= 0 && y < staticthis->mode.vRes)
+			staticthis->interruptPixelLine(y, pixels, base, arg);
+	}
+
+	if (renderLine == 0)
 		staticthis->vSyncPassed = true;
+
+	//update to provide currently outed buffer descriptor and line (increased by 1)
+	//staticthis->currentLine = (staticthis->currentLine + 1) % staticthis->totalLines;
+	//staticthis->dmaBufferDescriptorActive = (staticthis->dmaBufferDescriptorActive + 1) % staticthis->dmaBufferDescriptorCount;
 }
 
 void IRAM_ATTR VGA14BitI::interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg)

--- a/src/VGA/VGA3BitI.h
+++ b/src/VGA/VGA3BitI.h
@@ -19,6 +19,7 @@ class VGA3BitI : public VGA, public GraphicsR1G1B1A1
 	VGA3BitI()	//8 bit based modes only work with I2S1
 		: VGA(1)
 	{
+		interruptStaticChild = &VGA3BitI::interrupt;
 	}
 
 	bool init(const Mode &mode, const int RPin, const int GPin, const int BPin, const int hsyncPin, const int vsyncPin, const int clockPin = -1)
@@ -29,7 +30,7 @@ class VGA3BitI : public VGA, public GraphicsR1G1B1A1
 			BPin,
 			-1, -1, -1,
 			hsyncPin, vsyncPin
-		};	
+		};
 		return VGA::init(mode, pinMap, 8, clockPin);
 	}
 
@@ -87,53 +88,61 @@ class VGA3BitI : public VGA, public GraphicsR1G1B1A1
 		return true; 
 	};
 
-	void interrupt()
-	{
-		unsigned long *signal = (unsigned long *)dmaBufferDescriptors[dmaBufferDescriptorActive].buffer();
-		unsigned long *pixels = &((unsigned long *)dmaBufferDescriptors[dmaBufferDescriptorActive].buffer())[(mode.hSync + mode.hBack) / 4];
-		unsigned long base, baseh;
-		if (currentLine >= mode.vFront && currentLine < mode.vFront + mode.vSync)
-		{
-			baseh = syncBits(true, true);
-			base = syncBits(false, true);
-		}
-		else
-		{
-			baseh = syncBits(true, false);
-			base =  syncBits(false, false);
-		}
-		for (int i = 0; i < mode.hSync / 4; i++)
-			signal[i] = baseh;
-		for (int i = mode.hSync / 4; i < (mode.hSync + mode.hBack) / 4; i++)
-			signal[i] = base;
+	static void interrupt(void *arg);
 
-		int y = (currentLine - mode.vFront - mode.vSync - mode.vBack) / mode.vDiv;
-		if (y >= 0 && y < mode.vRes)
-			interruptPixelLine(y, pixels, base);
-		else
-			for (int i = 0; i < mode.hRes / 4; i++)
-			{
-				pixels[i] = base;
-			}
-		for (int i = 0; i < mode.hFront / 4; i++)
-			signal[i + (mode.hSync + mode.hBack + mode.hRes) / 4] = base;
-		currentLine = (currentLine + 1) % totalLines;
-		dmaBufferDescriptorActive = (dmaBufferDescriptorActive + 1) % dmaBufferDescriptorCount;
-		if (currentLine == 0)
-			vSync();
-	}
-
-	void interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits)
-	{
-		unsigned char *line = frontBuffer[y];
-		int j = 0;
-		for (int i = 0; i < mode.hRes / 4; i++)
-		{
-			int p0 = (line[j] >> 0) & 7;
-			int p1 = (line[j++] >> 4) & 7;
-			int p2 = (line[j] >> 0) & 7;
-			int p3 = (line[j++] >> 4) & 7;
-			pixels[i] = syncBits | (p2 << 0) | (p3 << 8) | (p0 << 16) | (p1 << 24);
-		}
-	}
+	static void interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg);
 };
+
+
+void IRAM_ATTR VGA3BitI::interrupt(void *arg)
+{
+	VGA3BitI * staticthis = (VGA3BitI *)arg;
+	
+	unsigned long *signal = (unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer();
+	unsigned long *pixels = &((unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer())[(staticthis->mode.hSync + staticthis->mode.hBack) / 4];
+	unsigned long base, baseh;
+	if (staticthis->currentLine >= staticthis->mode.vFront && staticthis->currentLine < staticthis->mode.vFront + staticthis->mode.vSync)
+	{
+		baseh = (staticthis->hsyncBit | staticthis->vsyncBit) * 0x1010101;
+		base = (staticthis->hsyncBitI | staticthis->vsyncBit) * 0x1010101;
+	}
+	else
+	{
+		baseh = (staticthis->hsyncBit | staticthis->vsyncBitI) * 0x1010101;
+		base = (staticthis->hsyncBitI | staticthis->vsyncBitI) * 0x1010101;
+	}
+	for (int i = 0; i < staticthis->mode.hSync / 4; i++)
+		signal[i] = baseh;
+	for (int i = staticthis->mode.hSync / 4; i < (staticthis->mode.hSync + staticthis->mode.hBack) / 4; i++)
+		signal[i] = base;
+
+	int y = (staticthis->currentLine - staticthis->mode.vFront - staticthis->mode.vSync - staticthis->mode.vBack) / staticthis->mode.vDiv;
+	if (y >= 0 && y < staticthis->mode.vRes)
+		staticthis->interruptPixelLine(y, pixels, base, arg);
+	else
+		for (int i = 0; i < staticthis->mode.hRes / 4; i++)
+		{
+			pixels[i] = base;
+		}
+	for (int i = 0; i < staticthis->mode.hFront / 4; i++)
+		signal[i + (staticthis->mode.hSync + staticthis->mode.hBack + staticthis->mode.hRes) / 4] = base;
+	staticthis->currentLine = (staticthis->currentLine + 1) % staticthis->totalLines;
+	staticthis->dmaBufferDescriptorActive = (staticthis->dmaBufferDescriptorActive + 1) % staticthis->dmaBufferDescriptorCount;
+	if (staticthis->currentLine == 0)
+		staticthis->vSyncPassed = true;
+}
+
+void IRAM_ATTR VGA3BitI::interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg)
+{
+	VGA3BitI * staticthis = (VGA3BitI *)arg;
+	unsigned char *line = staticthis->frontBuffer[y];
+	int j = 0;
+	for (int i = 0; i < staticthis->mode.hRes / 4; i++)
+	{
+		int p0 = (line[j] >> 0) & 7;
+		int p1 = (line[j++] >> 4) & 7;
+		int p2 = (line[j] >> 0) & 7;
+		int p3 = (line[j++] >> 4) & 7;
+		pixels[i] = syncBits | (p2 << 0) | (p3 << 8) | (p0 << 16) | (p1 << 24);
+	}
+}

--- a/src/VGA/VGA3BitI.h
+++ b/src/VGA/VGA3BitI.h
@@ -19,6 +19,7 @@ class VGA3BitI : public VGA, public GraphicsR1G1B1A1
 	VGA3BitI()	//8 bit based modes only work with I2S1
 		: VGA(1)
 	{
+		lineBufferCount = 3;
 		interruptStaticChild = &VGA3BitI::interrupt;
 	}
 
@@ -69,6 +70,83 @@ class VGA3BitI : public VGA, public GraphicsR1G1B1A1
 		setResolution(xres, yres);
 	}
 
+	void *vBlankLineBuffer;
+	void *vSyncLineBuffer;
+	void **vActiveLineBuffer;
+
+	//complete ring of buffer descriptors for one frame
+	//actual linebuffers only for some lines rendered ahead
+	virtual void allocateLineBuffers()
+	{
+		//lenght of each line
+		int samples = mode.hFront + mode.hSync + mode.hBack + mode.hRes;
+		int bytes = samples * bytesPerSample();
+
+		//create and fill the buffers with their default values
+
+		//create the buffers
+		//1 blank prototype line for vFront and vBack
+		vBlankLineBuffer = DMABufferDescriptor::allocateBuffer(bytes, true);
+		//1 sync prototype line for vSync
+		vSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytes, true);
+		//n lines as buffer for active lines
+		int ActiveLinesBufferCount = lineBufferCount;
+		vActiveLineBuffer = (void **)malloc(ActiveLinesBufferCount * sizeof(void *));
+		if(!vActiveLineBuffer)
+			ERROR("Not enough memory for ActiveLineBuffer buffer");
+		for (int i = 0; i < ActiveLinesBufferCount; i++)
+		{
+			vActiveLineBuffer[i] = DMABufferDescriptor::allocateBuffer(bytes, true);
+		}
+
+		//fill the buffers with their default values
+		//(bytesPerSample() == 1)
+		for (int i = 0; i < samples; i++)
+		{
+			if (i < mode.hSync)
+			{
+				((unsigned char *)vSyncLineBuffer)[i ^ 2] = hsyncBit | vsyncBit;
+				((unsigned char *)vBlankLineBuffer)[i ^ 2] = hsyncBit | vsyncBitI;
+			}
+			else
+			{
+				((unsigned char *)vSyncLineBuffer)[i ^ 2] = hsyncBitI | vsyncBit;
+				((unsigned char *)vBlankLineBuffer)[i ^ 2] = hsyncBitI | vsyncBitI;
+			}
+		}
+		for (int i = 0; i < ActiveLinesBufferCount; i++)
+		{
+			memcpy(vActiveLineBuffer[i], vBlankLineBuffer, bytes);
+		}
+
+		//allocate DMA buffer descriptors for the whole frame
+		dmaBufferDescriptorCount = totalLines;
+		dmaBufferDescriptors = DMABufferDescriptor::allocateDescriptors(dmaBufferDescriptorCount);
+		//link all buffer descriptors in a ring
+		for (int i = 0; i < dmaBufferDescriptorCount; i++)
+			dmaBufferDescriptors[i].next(dmaBufferDescriptors[(i + 1) % dmaBufferDescriptorCount]);
+
+		//assign the buffers accross the DMA buffer descriptors
+		//CONVENTION: the frame starts after the last active line of previous frame
+		int d = 0;
+		for (int i = 0; i < mode.vFront; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vBlankLineBuffer, bytes);
+		}
+		for (int i = 0; i < mode.vSync; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vSyncLineBuffer, bytes);
+		}
+		for (int i = 0; i < mode.vBack; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vBlankLineBuffer, bytes);
+		}
+		for (int i = 0; i < mode.vRes; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vActiveLineBuffer[i % ActiveLinesBufferCount], bytes);
+		}
+	}
+
 	virtual void show(bool vSync = false)
 	{
 		if (!frameBufferCount)
@@ -97,39 +175,34 @@ class VGA3BitI : public VGA, public GraphicsR1G1B1A1
 void IRAM_ATTR VGA3BitI::interrupt(void *arg)
 {
 	VGA3BitI * staticthis = (VGA3BitI *)arg;
-	
-	unsigned long *signal = (unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer();
-	unsigned long *pixels = &((unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer())[(staticthis->mode.hSync + staticthis->mode.hBack) / 4];
-	unsigned long base, baseh;
-	if (staticthis->currentLine >= staticthis->mode.vFront && staticthis->currentLine < staticthis->mode.vFront + staticthis->mode.vSync)
-	{
-		baseh = (staticthis->hsyncBit | staticthis->vsyncBit) * 0x1010101;
-		base = (staticthis->hsyncBitI | staticthis->vsyncBit) * 0x1010101;
-	}
-	else
-	{
-		baseh = (staticthis->hsyncBit | staticthis->vsyncBitI) * 0x1010101;
-		base = (staticthis->hsyncBitI | staticthis->vsyncBitI) * 0x1010101;
-	}
-	for (int i = 0; i < staticthis->mode.hSync / 4; i++)
-		signal[i] = baseh;
-	for (int i = staticthis->mode.hSync / 4; i < (staticthis->mode.hSync + staticthis->mode.hBack) / 4; i++)
-		signal[i] = base;
 
-	int y = (staticthis->currentLine - staticthis->mode.vFront - staticthis->mode.vSync - staticthis->mode.vBack) / staticthis->mode.vDiv;
-	if (y >= 0 && y < staticthis->mode.vRes)
-		staticthis->interruptPixelLine(y, pixels, base, arg);
-	else
-		for (int i = 0; i < staticthis->mode.hRes / 4; i++)
-		{
-			pixels[i] = base;
-		}
-	for (int i = 0; i < staticthis->mode.hFront / 4; i++)
-		signal[i + (staticthis->mode.hSync + staticthis->mode.hBack + staticthis->mode.hRes) / 4] = base;
-	staticthis->currentLine = (staticthis->currentLine + 1) % staticthis->totalLines;
-	staticthis->dmaBufferDescriptorActive = (staticthis->dmaBufferDescriptorActive + 1) % staticthis->dmaBufferDescriptorCount;
-	if (staticthis->currentLine == 0)
+	//fix for skipped lines due to skipped interupts during wifi activity
+	DMABufferDescriptor *currentDmaBufferDescriptor = (DMABufferDescriptor *)REG_READ(I2S_OUT_EOF_DES_ADDR_REG(staticthis->i2sIndex));
+	staticthis->dmaBufferDescriptorActive = ((uint32_t)currentDmaBufferDescriptor - (uint32_t)staticthis->dmaBufferDescriptors)/sizeof(DMABufferDescriptor);
+	staticthis->currentLine = staticthis->dmaBufferDescriptorActive; //equivalent in this configuration
+	
+	int vInactiveLinesCount = staticthis->mode.vFront + staticthis->mode.vSync + staticthis->mode.vBack;
+	
+	//render ahead (the lenght of buffered lines)
+	int renderLine = (staticthis->currentLine + staticthis->lineBufferCount) % staticthis->totalLines;
+	
+	if (renderLine >= vInactiveLinesCount)
+	{
+		int renderActiveLine = renderLine - vInactiveLinesCount;
+		unsigned long *pixels = &((unsigned long *)staticthis->vActiveLineBuffer[renderActiveLine % staticthis->lineBufferCount])[(staticthis->mode.hSync + staticthis->mode.hBack) / 4];
+		unsigned long base = (staticthis->hsyncBitI | staticthis->vsyncBitI) * 0x1010101;
+
+		int y = renderActiveLine / staticthis->mode.vDiv;
+		if (y >= 0 && y < staticthis->mode.vRes)
+			staticthis->interruptPixelLine(y, pixels, base, arg);
+	}
+
+	if (renderLine == 0)
 		staticthis->vSyncPassed = true;
+
+	//update to provide currently outed buffer descriptor and line (increased by 1)
+	//staticthis->currentLine = (staticthis->currentLine + 1) % staticthis->totalLines;
+	//staticthis->dmaBufferDescriptorActive = (staticthis->dmaBufferDescriptorActive + 1) % staticthis->dmaBufferDescriptorCount;
 }
 
 void IRAM_ATTR VGA3BitI::interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg)

--- a/src/VGA/VGA6BitI.h
+++ b/src/VGA/VGA6BitI.h
@@ -19,9 +19,10 @@ class VGA6BitI : public VGA, public GraphicsR2G2B2A2
 	VGA6BitI()	//8 bit based modes only work with I2S1
 		: VGA(1)
 	{
+		interruptStaticChild = &VGA6BitI::interrupt;
 	}
 
-	bool init(Mode &mode,
+	bool init(const Mode &mode,
 			  const int R0Pin, const int R1Pin,
 			  const int G0Pin, const int G1Pin,
 			  const int B0Pin, const int B1Pin,
@@ -33,7 +34,6 @@ class VGA6BitI : public VGA, public GraphicsR2G2B2A2
 			B0Pin, B1Pin,
 			hsyncPin, vsyncPin
 		};
-
 		return VGA::init(mode, pinMap, 8, clockPin);
 	}
 
@@ -47,8 +47,7 @@ class VGA6BitI : public VGA, public GraphicsR2G2B2A2
 			pinMap[i + 4] = bluePins[i];
 		}
 		pinMap[6] = hsyncPin;
-		pinMap[7] = vsyncPin;			
-		return VGA::init(mode, pinMap, 8, clockPin);
+		pinMap[7] = vsyncPin;			return VGA::init(mode, pinMap, 8, clockPin);
 	}
 
 	bool init(const Mode &mode, const PinConfig &pinConfig)
@@ -105,53 +104,61 @@ class VGA6BitI : public VGA, public GraphicsR2G2B2A2
 		return true; 
 	};
 
-	void interrupt()
-	{
-		unsigned long *signal = (unsigned long *)dmaBufferDescriptors[dmaBufferDescriptorActive].buffer();
-		unsigned long *pixels = &((unsigned long *)dmaBufferDescriptors[dmaBufferDescriptorActive].buffer())[(mode.hSync + mode.hBack) / 4];
-		unsigned long base, baseh;
-		if (currentLine >= mode.vFront && currentLine < mode.vFront + mode.vSync)
-		{
-			baseh = syncBits(true, true);
-			base = syncBits(false, true);
-		}
-		else
-		{
-			baseh = syncBits(true, false);
-			base =  syncBits(false, false);
-		}
-		for (int i = 0; i < mode.hSync / 4; i++)
-			signal[i] = baseh;
-		for (int i = mode.hSync / 4; i < (mode.hSync + mode.hBack) / 4; i++)
-			signal[i] = base;
+	static void interrupt(void *arg);
 
-		int y = (currentLine - mode.vFront - mode.vSync - mode.vBack) / mode.vDiv;
-		if (y >= 0 && y < mode.vRes)
-			interruptPixelLine(y, pixels, base);
-		else
-			for (int i = 0; i < mode.hRes / 4; i++)
-			{
-				pixels[i] = base;
-			}
-		for (int i = 0; i < mode.hFront / 4; i++)
-			signal[i + (mode.hSync + mode.hBack + mode.hRes) / 4] = base;
-		currentLine = (currentLine + 1) % totalLines;
-		dmaBufferDescriptorActive = (dmaBufferDescriptorActive + 1) % dmaBufferDescriptorCount;
-		if (currentLine == 0)
-			vSync();
-	}
-
-	void interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits)
-	{
-		unsigned char *line = frontBuffer[y];
-		int j = 0;
-		for (int i = 0; i < mode.hRes / 4; i++)
-		{
-			int p0 = (line[j] >> 0) & 7;
-			int p1 = (line[j++] >> 4) & 7;
-			int p2 = (line[j] >> 0) & 7;
-			int p3 = (line[j++] >> 4) & 7;
-			pixels[i] = syncBits | (p2 << 0) | (p3 << 8) | (p0 << 16) | (p1 << 24);
-		}
-	}
+	static void interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg);
 };
+
+
+void IRAM_ATTR VGA6BitI::interrupt(void *arg)
+{
+	VGA6BitI * staticthis = (VGA6BitI *)arg;
+	
+	unsigned long *signal = (unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer();
+	unsigned long *pixels = &((unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer())[(staticthis->mode.hSync + staticthis->mode.hBack) / 4];
+	unsigned long base, baseh;
+	if (staticthis->currentLine >= staticthis->mode.vFront && staticthis->currentLine < staticthis->mode.vFront + staticthis->mode.vSync)
+	{
+		baseh = (staticthis->hsyncBit | staticthis->vsyncBit) * 0x1010101;
+		base = (staticthis->hsyncBitI | staticthis->vsyncBit) * 0x1010101;
+	}
+	else
+	{
+		baseh = (staticthis->hsyncBit | staticthis->vsyncBitI) * 0x1010101;
+		base = (staticthis->hsyncBitI | staticthis->vsyncBitI) * 0x1010101;
+	}
+	for (int i = 0; i < staticthis->mode.hSync / 4; i++)
+		signal[i] = baseh;
+	for (int i = staticthis->mode.hSync / 4; i < (staticthis->mode.hSync + staticthis->mode.hBack) / 4; i++)
+		signal[i] = base;
+
+	int y = (staticthis->currentLine - staticthis->mode.vFront - staticthis->mode.vSync - staticthis->mode.vBack) / staticthis->mode.vDiv;
+	if (y >= 0 && y < staticthis->mode.vRes)
+		staticthis->interruptPixelLine(y, pixels, base, arg);
+	else
+		for (int i = 0; i < staticthis->mode.hRes / 4; i++)
+		{
+			pixels[i] = base;
+		}
+	for (int i = 0; i < staticthis->mode.hFront / 4; i++)
+		signal[i + (staticthis->mode.hSync + staticthis->mode.hBack + staticthis->mode.hRes) / 4] = base;
+	staticthis->currentLine = (staticthis->currentLine + 1) % staticthis->totalLines;
+	staticthis->dmaBufferDescriptorActive = (staticthis->dmaBufferDescriptorActive + 1) % staticthis->dmaBufferDescriptorCount;
+	if (staticthis->currentLine == 0)
+		staticthis->vSyncPassed = true;
+}
+
+void IRAM_ATTR VGA6BitI::interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg)
+{
+	VGA6BitI * staticthis = (VGA6BitI *)arg;
+	unsigned char *line = staticthis->frontBuffer[y];
+	int j = 0;
+	for (int i = 0; i < staticthis->mode.hRes / 4; i++)
+	{
+		int p0 = (line[j++]) & 63;
+		int p1 = (line[j++]) & 63;
+		int p2 = (line[j++]) & 63;
+		int p3 = (line[j++]) & 63;
+		pixels[i] = syncBits | (p2 << 0) | (p3 << 8) | (p0 << 16) | (p1 << 24);
+	}
+}

--- a/src/VGA/VGA6BitI.h
+++ b/src/VGA/VGA6BitI.h
@@ -19,6 +19,7 @@ class VGA6BitI : public VGA, public GraphicsR2G2B2A2
 	VGA6BitI()	//8 bit based modes only work with I2S1
 		: VGA(1)
 	{
+		lineBufferCount = 3;
 		interruptStaticChild = &VGA6BitI::interrupt;
 	}
 
@@ -47,7 +48,8 @@ class VGA6BitI : public VGA, public GraphicsR2G2B2A2
 			pinMap[i + 4] = bluePins[i];
 		}
 		pinMap[6] = hsyncPin;
-		pinMap[7] = vsyncPin;			return VGA::init(mode, pinMap, 8, clockPin);
+		pinMap[7] = vsyncPin;
+		return VGA::init(mode, pinMap, 8, clockPin);
 	}
 
 	bool init(const Mode &mode, const PinConfig &pinConfig)
@@ -85,6 +87,83 @@ class VGA6BitI : public VGA, public GraphicsR2G2B2A2
 		setResolution(xres, yres);
 	}
 
+	void *vBlankLineBuffer;
+	void *vSyncLineBuffer;
+	void **vActiveLineBuffer;
+
+	//complete ring of buffer descriptors for one frame
+	//actual linebuffers only for some lines rendered ahead
+	virtual void allocateLineBuffers()
+	{
+		//lenght of each line
+		int samples = mode.hFront + mode.hSync + mode.hBack + mode.hRes;
+		int bytes = samples * bytesPerSample();
+
+		//create and fill the buffers with their default values
+
+		//create the buffers
+		//1 blank prototype line for vFront and vBack
+		vBlankLineBuffer = DMABufferDescriptor::allocateBuffer(bytes, true);
+		//1 sync prototype line for vSync
+		vSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytes, true);
+		//n lines as buffer for active lines
+		int ActiveLinesBufferCount = lineBufferCount;
+		vActiveLineBuffer = (void **)malloc(ActiveLinesBufferCount * sizeof(void *));
+		if(!vActiveLineBuffer)
+			ERROR("Not enough memory for ActiveLineBuffer buffer");
+		for (int i = 0; i < ActiveLinesBufferCount; i++)
+		{
+			vActiveLineBuffer[i] = DMABufferDescriptor::allocateBuffer(bytes, true);
+		}
+
+		//fill the buffers with their default values
+		//(bytesPerSample() == 1)
+		for (int i = 0; i < samples; i++)
+		{
+			if (i < mode.hSync)
+			{
+				((unsigned char *)vSyncLineBuffer)[i ^ 2] = hsyncBit | vsyncBit;
+				((unsigned char *)vBlankLineBuffer)[i ^ 2] = hsyncBit | vsyncBitI;
+			}
+			else
+			{
+				((unsigned char *)vSyncLineBuffer)[i ^ 2] = hsyncBitI | vsyncBit;
+				((unsigned char *)vBlankLineBuffer)[i ^ 2] = hsyncBitI | vsyncBitI;
+			}
+		}
+		for (int i = 0; i < ActiveLinesBufferCount; i++)
+		{
+			memcpy(vActiveLineBuffer[i], vBlankLineBuffer, bytes);
+		}
+
+		//allocate DMA buffer descriptors for the whole frame
+		dmaBufferDescriptorCount = totalLines;
+		dmaBufferDescriptors = DMABufferDescriptor::allocateDescriptors(dmaBufferDescriptorCount);
+		//link all buffer descriptors in a ring
+		for (int i = 0; i < dmaBufferDescriptorCount; i++)
+			dmaBufferDescriptors[i].next(dmaBufferDescriptors[(i + 1) % dmaBufferDescriptorCount]);
+
+		//assign the buffers accross the DMA buffer descriptors
+		//CONVENTION: the frame starts after the last active line of previous frame
+		int d = 0;
+		for (int i = 0; i < mode.vFront; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vBlankLineBuffer, bytes);
+		}
+		for (int i = 0; i < mode.vSync; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vSyncLineBuffer, bytes);
+		}
+		for (int i = 0; i < mode.vBack; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vBlankLineBuffer, bytes);
+		}
+		for (int i = 0; i < mode.vRes; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vActiveLineBuffer[i % ActiveLinesBufferCount], bytes);
+		}
+	}
+
 	virtual void show(bool vSync = false)
 	{
 		if (!frameBufferCount)
@@ -113,39 +192,34 @@ class VGA6BitI : public VGA, public GraphicsR2G2B2A2
 void IRAM_ATTR VGA6BitI::interrupt(void *arg)
 {
 	VGA6BitI * staticthis = (VGA6BitI *)arg;
-	
-	unsigned long *signal = (unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer();
-	unsigned long *pixels = &((unsigned long *)staticthis->dmaBufferDescriptors[staticthis->dmaBufferDescriptorActive].buffer())[(staticthis->mode.hSync + staticthis->mode.hBack) / 4];
-	unsigned long base, baseh;
-	if (staticthis->currentLine >= staticthis->mode.vFront && staticthis->currentLine < staticthis->mode.vFront + staticthis->mode.vSync)
-	{
-		baseh = (staticthis->hsyncBit | staticthis->vsyncBit) * 0x1010101;
-		base = (staticthis->hsyncBitI | staticthis->vsyncBit) * 0x1010101;
-	}
-	else
-	{
-		baseh = (staticthis->hsyncBit | staticthis->vsyncBitI) * 0x1010101;
-		base = (staticthis->hsyncBitI | staticthis->vsyncBitI) * 0x1010101;
-	}
-	for (int i = 0; i < staticthis->mode.hSync / 4; i++)
-		signal[i] = baseh;
-	for (int i = staticthis->mode.hSync / 4; i < (staticthis->mode.hSync + staticthis->mode.hBack) / 4; i++)
-		signal[i] = base;
 
-	int y = (staticthis->currentLine - staticthis->mode.vFront - staticthis->mode.vSync - staticthis->mode.vBack) / staticthis->mode.vDiv;
-	if (y >= 0 && y < staticthis->mode.vRes)
-		staticthis->interruptPixelLine(y, pixels, base, arg);
-	else
-		for (int i = 0; i < staticthis->mode.hRes / 4; i++)
-		{
-			pixels[i] = base;
-		}
-	for (int i = 0; i < staticthis->mode.hFront / 4; i++)
-		signal[i + (staticthis->mode.hSync + staticthis->mode.hBack + staticthis->mode.hRes) / 4] = base;
-	staticthis->currentLine = (staticthis->currentLine + 1) % staticthis->totalLines;
-	staticthis->dmaBufferDescriptorActive = (staticthis->dmaBufferDescriptorActive + 1) % staticthis->dmaBufferDescriptorCount;
-	if (staticthis->currentLine == 0)
+	//fix for skipped lines due to skipped interupts during wifi activity
+	DMABufferDescriptor *currentDmaBufferDescriptor = (DMABufferDescriptor *)REG_READ(I2S_OUT_EOF_DES_ADDR_REG(staticthis->i2sIndex));
+	staticthis->dmaBufferDescriptorActive = ((uint32_t)currentDmaBufferDescriptor - (uint32_t)staticthis->dmaBufferDescriptors)/sizeof(DMABufferDescriptor);
+	staticthis->currentLine = staticthis->dmaBufferDescriptorActive; //equivalent in this configuration
+	
+	int vInactiveLinesCount = staticthis->mode.vFront + staticthis->mode.vSync + staticthis->mode.vBack;
+	
+	//render ahead (the lenght of buffered lines)
+	int renderLine = (staticthis->currentLine + staticthis->lineBufferCount) % staticthis->totalLines;
+	
+	if (renderLine >= vInactiveLinesCount)
+	{
+		int renderActiveLine = renderLine - vInactiveLinesCount;
+		unsigned long *pixels = &((unsigned long *)staticthis->vActiveLineBuffer[renderActiveLine % staticthis->lineBufferCount])[(staticthis->mode.hSync + staticthis->mode.hBack) / 4];
+		unsigned long base = (staticthis->hsyncBitI | staticthis->vsyncBitI) * 0x1010101;
+
+		int y = renderActiveLine / staticthis->mode.vDiv;
+		if (y >= 0 && y < staticthis->mode.vRes)
+			staticthis->interruptPixelLine(y, pixels, base, arg);
+	}
+
+	if (renderLine == 0)
 		staticthis->vSyncPassed = true;
+
+	//update to provide currently outed buffer descriptor and line (increased by 1)
+	//staticthis->currentLine = (staticthis->currentLine + 1) % staticthis->totalLines;
+	//staticthis->dmaBufferDescriptorActive = (staticthis->dmaBufferDescriptorActive + 1) % staticthis->dmaBufferDescriptorCount;
 }
 
 void IRAM_ATTR VGA6BitI::interruptPixelLine(int y, unsigned long *pixels, unsigned long syncBits, void *arg)


### PR DESCRIPTION
(Fix incompatibility - from previous commit)
Create buffer descriptors for all lines in the frame, with fixed lines for vSync, and a small buffer where hSync is also already fixed.
Render active video lines live in the small buffer.
Keep the rendered line in sync reading the pointer to the buffer descriptor that points to the DMA buffer just outed by I2S.
Fixes #39 