### PR TITLE
VGA 8 bit dac (internal)

### DIFF
--- a/examples/8BitDACMode/8BitDACMode.ino
+++ b/examples/8BitDACMode/8BitDACMode.ino
@@ -1,0 +1,58 @@
+//You need to connect a VGA screen cable to the pins specified below.
+//cc by-sa 4.0 license
+//Martin-Laclaustra
+/*
+  CONNECTION
+  
+  A) voltageDivider = false; B) voltageDivider = true (last init parameter)
+  
+     55 shades                  255 shades
+  
+  ESP32        VGA           ESP32                       VGA     
+  -----+                     -----+    ____ 100 ohm              
+      G|-   +---- R              G|---|____|+         +---- R    
+  pin25|----+---- G          pin25|---|____|+---------+---- G    
+  pin26|-   +---- B          pin26|-        220 ohm   +---- B    
+  pin X|--------- HSYNC      pin X|------------------------ HSYNC
+  pin Y|--------- VSYNC      pin Y|------------------------ VSYNC
+  -----+                     -----+                              
+  
+  Connect pin 25 or 26
+  Connect the 3 channels in parallel or whatever combination of them
+    depending on the monochrome color of choice
+*/
+
+#include <ESP32Lib.h>
+#include <Ressources/Font6x8.h>
+
+//pin configuration
+const int outputPin = 25;
+const int hsyncPin = 16;
+const int vsyncPin = 4;
+
+VGA8BitDAC vga;
+
+void setup()
+{
+	//initializing vga at the specified pins
+  //output pin and boolean for voltage divider can be omitted
+  vga.init(vga.MODE320x240, hsyncPin, vsyncPin, outputPin, false);
+	//selecting the font
+	vga.setFont(Font6x8);
+	//displaying the test pattern
+  vga.rect(30, 88, 255+5, 40+4, 127);
+  for(int x = 0; x < 256; x++)
+  {
+    vga.fillRect(x + 32, 90, 1, 40, x);
+    if(x % 16 == 0)
+    {
+      vga.fillRect(x + 32, 85, 1, 4, 255);
+      vga.setCursor(x + 32 - 3, 78);
+      vga.print(x,HEX);
+    }
+  }
+}
+
+void loop()
+{
+}

--- a/src/ESP32Lib.h
+++ b/src/ESP32Lib.h
@@ -6,6 +6,7 @@
 #include <VGA/VGA6Bit.h>
 #include <VGA/VGA3BitI.h>
 #include <VGA/VGA3Bit.h>
+#include <VGA/VGA8BitDAC.h>
 #include <Composite/CompositeL8.h>
 #include <Composite/CompositePAL8.h>
 

--- a/src/Graphics/GraphicsX6S2W8Swapped.h
+++ b/src/Graphics/GraphicsX6S2W8Swapped.h
@@ -1,0 +1,100 @@
+/*
+	Author: bitluni 2019
+	License: 
+	Creative Commons Attribution ShareAlike 4.0
+	https://creativecommons.org/licenses/by-sa/4.0/
+	
+	For further details check out: 
+		https://youtube.com/bitlunislab
+		https://github.com/bitluni
+		http://bitluni.net
+*/
+#pragma once
+#include "Graphics.h"
+
+class GraphicsX6S2W8Swapped: public Graphics<unsigned short>
+{
+	public:
+	typedef unsigned short Color;
+	static const Color RGBAXMask = 0xff3f;
+	Color SBits;
+	int colorDepthConversionFactor = 256;
+	int colorMinValue = 0;
+	int colorMaxValue = 255;
+
+
+	GraphicsX6S2W8Swapped()
+	{
+		SBits = 0xc0;
+		frontColor = 0xff00;
+	}
+
+	virtual int R(Color c) const
+	{
+		return c >> 8;
+	}
+	virtual int G(Color c) const
+	{
+		return c >> 8;
+	}
+	virtual int B(Color c) const
+	{
+		return c >> 8;
+	}
+	virtual int A(Color c) const
+	{
+		return 255;
+	}
+
+	virtual Color RGBA(int r, int g, int b, int a = 255) const
+	{
+		return (r * 2126 + g * 7152 + b * 722) / 10000;
+	}
+
+	virtual void dotFast(int x, int y, Color color)
+	{
+		backBuffer[y][x^1] = ((((colorMinValue<<8) + colorDepthConversionFactor*(int)color) & 0xFF00) & RGBAXMask) | SBits;
+	}
+
+	virtual void dot(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			dotFast(x, y, color);
+	}
+
+	virtual void dotAdd(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+		{
+			int newColor = get(x, y);
+			newColor += color;
+			dotFast(x, y, (newColor > 0xff) ? 0xff : newColor);
+		}
+	}
+	
+	virtual void dotMix(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres && (color > 0))
+			dotFast(x, y, (get(x, y) + color)>>1);
+	}
+	
+	virtual Color get(int x, int y)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			return (((backBuffer[y][x^1] & RGBAXMask) & 0xFF00) - (colorMinValue<<8)) / colorDepthConversionFactor;
+		return 0;
+	}
+
+	virtual void clear(Color color = 0)
+	{
+		Color newColor = ((((colorMinValue<<8) + colorDepthConversionFactor*(int)color) & 0xFF00) & RGBAXMask) | SBits;
+		for (int y = 0; y < this->yres; y++)
+			for (int x = 0; x < this->xres; x++)
+				this->backBuffer[y][x] = newColor;
+	}
+
+	virtual Color** allocateFrameBuffer()
+	{
+		return Graphics<Color>::allocateFrameBuffer(xres, yres, (Color)SBits);
+	}
+};

--- a/src/VGA/VGA8BitDAC.h
+++ b/src/VGA/VGA8BitDAC.h
@@ -1,0 +1,182 @@
+/*
+	Author: Martin-Laclaustra 2020
+	License: 
+	Creative Commons Attribution ShareAlike 4.0
+	https://creativecommons.org/licenses/by-sa/4.0/
+	
+	For further details check out: 
+		https://github.com/bitluni
+*/
+
+/*
+	CONNECTION
+	
+	A) voltageDivider = false; B) voltageDivider = true
+	
+	   55 shades                  255 shades
+	
+	ESP32        VGA           ESP32                       VGA     
+	-----+                     -----+    ____ 100 ohm              
+	    G|-   +---- R              G|---|____|+         +---- R    
+	pin25|----+---- G          pin25|---|____|+---------+---- G    
+	pin26|-   +---- B          pin26|-        220 ohm   +---- B    
+	pin X|--------- HSYNC      pin X|------------------------ HSYNC
+	pin Y|--------- VSYNC      pin Y|------------------------ VSYNC
+	-----+                     -----+                              
+	
+	Connect pin 25 or 26
+	Connect the 3 channels in parallel or whatever combination of them
+	  depending on the monochrome color of choice
+*/
+#pragma once
+#include "VGA.h"
+#include "../Graphics/GraphicsX6S2W8Swapped.h"
+
+#include "driver/dac.h"
+
+#include <soc/rtc.h>
+#include <driver/rtc_io.h>
+
+
+
+class VGA8BitDAC : public VGA, public GraphicsX6S2W8Swapped
+{
+  public:
+	VGA8BitDAC() //DAC based modes only work with I2S0
+		: VGA(0)
+	{
+		lineBufferCount = 3;
+		colorMaxValue = 54;
+	}
+
+	bool init(const Mode &mode, const int hsyncPin, const int vsyncPin, const int outputPin = 25, const bool voltageDivider = false)
+	{
+		int pinMap[16] = {
+			-1, -1, -1, -1,
+			-1, -1, hsyncPin, vsyncPin,
+			-1, -1, -1, -1,
+			-1, -1, -1, -1
+		};
+		this->outputPin = outputPin;
+		this->voltageDivider = voltageDivider;
+		if(voltageDivider)
+		{
+			colorMaxValue = 255;
+		}
+		//values must be shifted to the MSByte to be output
+		//which is equivalent to multiplying by 256
+		//instead of shifting, do not divide here:
+		//colorDepthConversionFactor = (colorMaxValue - colorMinValue + 1)/256;
+		colorDepthConversionFactor = colorMaxValue - colorMinValue + 1;
+		return initDAC(mode, pinMap, 16, -1);
+	}
+
+	bool init(const Mode &mode, const PinConfig &pinConfig)
+	{
+		int pins[16];
+		pinConfig.fill14Bit(pins);
+		this->hsyncPin = pins[14];
+		this->vsyncPin = pins[15];
+		for (int i = 0; i < 16; i++)
+		{
+			pins[i] = -1;
+		}
+		pins[6] = this->hsyncPin;
+		pins[7] = this->vsyncPin;
+		colorDepthConversionFactor = colorMaxValue - colorMinValue + 1;
+		return initDAC(mode, pins, 16, pinConfig.clock);
+	}
+
+	bool initDAC(const Mode &mode, const int *pinMap, const int bitCount, const int clockPin)
+	{
+		i2s_dev_t *i2sDevices[] = {&I2S0, &I2S1};
+		this->mode = mode;
+		int xres = mode.hRes;
+		int yres = mode.vRes / mode.vDiv;
+		initSyncBits();
+		propagateResolution(xres, yres);
+		this->hsyncPin = hsyncPin;
+		this->vsyncPin = vsyncPin;
+		totalLines = mode.linesPerField();
+		allocateLineBuffers();
+		currentLine = 0;
+		vSyncPassed = false;
+		initParallelOutputMode(pinMap, mode.pixelClock, bitCount, clockPin);
+		volatile i2s_dev_t &i2s = *i2sDevices[i2sIndex];
+		i2s.conf2.lcd_en = 1;
+		i2s.conf.tx_right_first = 1;
+		i2s.conf2.camera_en = 0;
+		dac_i2s_enable();
+		dac_output_enable(outputPin==25?DAC_CHANNEL_1:DAC_CHANNEL_2);
+		startTX();
+		return true;
+	}
+
+	virtual void initSyncBits()
+	{
+		hsyncBitI = mode.hSyncPolarity ? 0x0040 : 0;
+		vsyncBitI = mode.vSyncPolarity ? 0x0080 : 0;
+		hsyncBit = hsyncBitI ^ 0x0040;
+		vsyncBit = vsyncBitI ^ 0x0080;
+		SBits = hsyncBitI | vsyncBitI;
+	}
+
+	virtual long syncBits(bool hSync, bool vSync)
+	{
+		return ((hSync ? hsyncBit : hsyncBitI) | (vSync ? vsyncBit : vsyncBitI)) * 0x00010001;
+	}
+
+	virtual int bytesPerSample() const
+	{
+		return 2;
+	}
+
+	virtual float pixelAspect() const
+	{
+		return 1;
+	}
+
+	virtual void propagateResolution(const int xres, const int yres)
+	{
+		setResolution(xres, yres);
+	}
+
+	int outputPin = 25;
+	bool voltageDivider = false;
+
+	virtual Color **allocateFrameBuffer()
+	{
+		return (Color **)DMABufferDescriptor::allocateDMABufferArray(yres, mode.hRes * bytesPerSample(), true, syncBits(false, false));
+	}
+
+	virtual void allocateLineBuffers()
+	{
+		VGA::allocateLineBuffers((void **)frameBuffers[0]);
+	}
+
+	virtual void show(bool vSync = false)
+	{
+		if (!frameBufferCount)
+			return;
+		if (vSync)
+		{
+			//TODO read the I2S docs to find out
+		}
+		Graphics::show(vSync);
+		if(dmaBufferDescriptors)
+			for (int i = 0; i < yres * mode.vDiv; i++)
+				dmaBufferDescriptors[(mode.vFront + mode.vSync + mode.vBack + i) * 2 + 1].setBuffer(frontBuffer[i / mode.vDiv], mode.hRes * bytesPerSample());
+	}
+
+	virtual void scroll(int dy, Color color)
+	{
+		Graphics::scroll(dy, color);
+		if (frameBufferCount == 1)
+			show();
+	}
+
+  protected:
+	virtual void interrupt()
+	{
+	}
+};


### PR DESCRIPTION
This mode uses internal DAC to display 55 (or 256 if a voltage divider is used) levels of grey, or the same number of color tones of a particular hue depending on the combination of vga channels connected to the output pin.
It works without any extra component.
Resolves #45 