### PR TITLE
Composite through internal DAC or resistor ladder parallel output

### DIFF
--- a/examples/CompositeDACColorMode/CompositeDACColorMode.ino
+++ b/examples/CompositeDACColorMode/CompositeDACColorMode.ino
@@ -1,0 +1,103 @@
+//You need to connect a composite TV input cable to the pins specified below.
+//cc by-sa 4.0 license
+//Martin-Laclaustra
+/*
+    CONNECTION
+
+    A) voltageDivider = false; B) voltageDivider = true
+
+       55 shades                  179 shades
+
+    ESP32        TV            ESP32                       TV     
+    -----+                     -----+    ____ 100 ohm
+        G|-                        G|---|____|+          
+    pin25|--------- Comp       pin25|---|____|+--------- Comp    
+    pin26|-                    pin26|-        150 ohm
+         |                          |
+         |                          |
+    -----+                     -----+                              
+
+    Connect pin 25 or 26
+  
+    C) R-2R resistor ladder; D) unequal rungs ladder
+
+       55 shades                  up to 254 shades?
+
+    ESP32        TV           ESP32                       TV
+    -----+                    -----+    ____ 
+        G|-+_____                 G|---|____|
+    pinA0|-| R2R |- Comp      pinA0|---|____|+--------- Comp
+    pinA1|-|     |            pinA1|---|____|
+    pinA2|-|     |              ...|
+      ...|-|_____|                 |
+    -----+                    -----+
+
+    Connect pins of your choice (A0...A8=any pins).
+    Custom ladders can be used by tweaking colorMinValue and colorMaxValue
+*/
+
+#include <ESP32Lib.h>
+#include <Ressources/CodePage437_8x8.h>
+#include <Composite/CompMode.h>
+
+//pin configuration for DAC
+const int outputPin = 25;
+
+CompositeColorDAC display;
+//CompositeColorLadder display;
+
+void setup()
+{
+  //initializing composite at the specified pins
+  //output pin and boolean for voltage divider can be omitted
+  //see Composite/CompMode.h for other modes
+  display.init(CompMode::MODENTSCColor240P, 25, false);
+  //display.init(CompMode::MODEPALColor288P, 25, false);
+  //use these for the ladder hardware configuration
+  //display.init(CompMode::MODENTSCColor240P, display.XPlayer);
+  //This PAL mode did not work with the ladder
+  //display.init(CompMode::MODEPALColor288P, display.XPlayer);
+  //But this PAL mode works
+  //display.init(ModeComposite(10, 30, 48, 312,  1,  6, 5, 5,  15, 288, 0, 0, 0, 0, 1, 6244533,5,16,4433619,true), display.XPlayer);
+  //NOTE: PAL color only works for CRT TVs, not LDC TVs
+
+
+  display.fillCircle(25 + 55, 50, 1 + 50 / 4, display.RGB(96, 0, 0));
+  display.fillCircle(25 + 55+30, 50, 1 + 50 / 4, display.RGB(0, 96, 0));
+  display.fillCircle(25 + 55+60, 50, 1 + 50 / 4, display.RGB(0, 0, 96));
+
+  display.fillCircle(100 + 25 + 55, 50, 1 + 50 / 4, display.RGB(255, 0, 0));
+  display.fillCircle(100 + 25 + 55+30, 50, 1 + 50 / 4, display.RGB(0, 255, 0));
+  display.fillCircle(100 + 25 + 55+60, 50, 1 + 50 / 4, display.RGB(0, 0, 255));
+
+  display.fillCircle(200 + 25 + 55, 50, 1 + 50 / 4, display.RGB(96, 96, 0));
+  display.fillCircle(200 + 25 + 55+30, 50, 1 + 50 / 4, display.RGB(0, 96, 96));
+  display.fillCircle(200 + 25 + 55+60, 50, 1 + 50 / 4, display.RGB(96, 0, 96));
+
+  display.fillCircle(300 + 25 + 55, 50, 1 + 50 / 4, display.RGB(255, 255, 0));
+  display.fillCircle(300 + 25 + 55+30, 50, 1 + 50 / 4, display.RGB(0, 255, 255));
+  display.fillCircle(300 + 25 + 55+60, 50, 1 + 50 / 4, display.RGB(255, 0, 255));
+
+
+
+  //selecting the font
+  display.setFont(CodePage437_8x8);
+  //displaying the test pattern
+  display.fillRect(8+30-4, 88-2, (2*255)+5+8, 40+4+4, display.RGB(127,127,127));
+  display.fillRect(8+30, 88, (2*255)+5, 40+4, display.RGB(0,0,0));
+  display.setTextColor(display.RGB(192,192,192));
+  for(int x = 0; x < 256*2; x+=2)
+  {
+    display.fillRect(8+x + 32, 90, 2, 40, display.RGB(x/2,x/2,x/2));
+    if(x % 32 == 0)
+    {
+      display.fillRect(8+x + 32, 85, 4, 4, display.RGB(255,255,255));
+      display.setCursor(8+x + 32 - 4, 78 - 4);
+      display.print(x/2,HEX);
+    }
+  }
+}
+
+void loop()
+{
+}

--- a/examples/CompositeDACMode/CompositeDACMode.ino
+++ b/examples/CompositeDACMode/CompositeDACMode.ino
@@ -1,0 +1,75 @@
+//You need to connect a composite TV input cable to the pins specified below.
+//cc by-sa 4.0 license
+//Martin-Laclaustra
+/*
+    CONNECTION
+
+    A) voltageDivider = false; B) voltageDivider = true
+
+       55 shades                  179 shades
+
+    ESP32        TV            ESP32                       TV     
+    -----+                     -----+    ____ 100 ohm
+        G|-                        G|---|____|+          
+    pin25|--------- Comp       pin25|---|____|+--------- Comp    
+    pin26|-                    pin26|-        220 ohm
+         |                          |
+         |                          |
+    -----+                     -----+                              
+
+    Connect pin 25 or 26
+  
+    C) R–2R resistor ladder; D) unequal rungs ladder
+
+       55 shades                  up to 254 shades?
+
+    ESP32        TV           ESP32                       TV
+    -----+                    -----+    ____ 
+        G|-+_____                 G|---|____|
+    pinA0|-| R2R |- Comp      pinA0|---|____|+--------- Comp
+    pinA1|-|     |            pinA1|---|____|
+    pinA2|-|     |              ...|
+      ...|-|_____|                 |
+    -----+                    -----+
+
+    Connect pins of your choice (A0...A8=any pins).
+    Custom ladders can be used by tweaking colorMinValue and colorMaxValue
+*/
+
+#include <ESP32Lib.h>
+#include <Ressources/Font6x8.h>
+#include <Composite/CompMode.h>
+
+//pin configuration for DAC
+const int outputPin = 25;
+
+CompositeGrayDAC display;
+//CompositeGrayLadder display;
+
+void setup()
+{
+  //initializing composite at the specified pins
+  //output pin and boolean for voltage divider can be omitted
+  //see Composite/CompMode.h for other modes
+  display.init(CompMode::MODEPAL288P, 25, false);
+  //display.init(CompMode::MODEPAL288P, display.XPlayer);
+
+  //selecting the font
+  display.setFont(Font6x8);
+  //displaying the test pattern
+  display.rect(30, 88, 255+5, 40+4, 127);
+  for(int x = 0; x < 256; x++)
+  {
+    display.fillRect(x + 32, 90, 1, 40, x);
+    if(x % 16 == 0)
+    {
+      display.fillRect(x + 32, 85, 1, 4, 255);
+      display.setCursor(x + 32 - 3, 78);
+      display.print(x,HEX);
+    }
+  }
+}
+
+void loop()
+{
+}

--- a/src/Composite/CompMode.cpp
+++ b/src/Composite/CompMode.cpp
@@ -121,3 +121,10 @@ const ModeComposite CompMode::MODENTSC240Pmax(20, 64, 76, 688,  1,  6, 6, 6,  12
 //75 ns/pix
 //848 pix/line, 63.6 us/line, 15.72327 kHz hSync, 4.8 us hSync
 //262 lines/field-progressiveframe, 16.6632 ms/field, 60.0125 Hz vSync
+
+
+//===========
+//COLOR MODES
+//===========
+const ModeComposite CompMode::MODEPALColor288P(18, 56, 94, 604,  1+78,  6, 5, 5,  15+10, 288-88, 0, 0, 0, 0, 1, 12051950,10,25,4433619,true);
+const ModeComposite CompMode::MODENTSCColor240P(20, 56, 72, 652,  1+36,  6, 6, 6,  12+4, 240-40, 0, 0, 0, 0, 1, 12560000,13,32,3579545,false);

--- a/src/Composite/CompMode.cpp
+++ b/src/Composite/CompMode.cpp
@@ -42,7 +42,7 @@ const ModeComposite CompMode::MODEPAL288P(12, 38, 62, 400,  1,  6, 5, 5,  15, 28
 //312 lines/field-progressiveframe, 19.968 ms/field, 50.080 Hz vSync
 
 
-const ModeComposite CompMode::MODEPAL576I(12, 38, 62, 400,  1,  5, 5, 5,  15, 288, 1, 2, 0, 1, 1, 8000000);
+const ModeComposite CompMode::MODEPAL576I(12, 38, 62, 400,  1,  5, 5, 5,  15, 288, 1, 0, 2, 1, 1, 8000000);
 //625 line / 25 frame
 //576 active lines
 
@@ -71,7 +71,7 @@ const ModeComposite CompMode::MODEPAL288Pmin(2, 5, 5, 52,  1,  6, 5, 5,  15, 288
 //312 lines/field-progressiveframe, 19.968 ms/field, 50.080 Hz vSync
 
 
-const ModeComposite CompMode::MODEPAL576Imin(2, 5, 5, 52,  1,  5, 5, 5,  15, 288, 1, 2, 0, 1, 1, 1000000);
+const ModeComposite CompMode::MODEPAL576Imin(2, 5, 5, 52,  1,  5, 5, 5,  15, 288, 1, 0, 2, 1, 1, 1000000);
 //625 line / 25 frame
 //576 active lines
 
@@ -80,7 +80,7 @@ const ModeComposite CompMode::MODEPAL576Imin(2, 5, 5, 52,  1,  5, 5, 5,  15, 288
 //312.5 lines/field, 20 ms/field, 50 Hz vSync
 
 
-const ModeComposite CompMode::MODEPAL576Idiv3(12, 38, 62, 400,  1,  5, 5, 5,  15, 288, 1, 2, 0, 1, 3, 8000000);
+const ModeComposite CompMode::MODEPAL576Idiv3(12, 38, 62, 400,  1,  5, 5, 5,  15, 288, 1, 0, 2, 1, 3, 8000000);
 //625 line / 25 frame
 //576 active lines
 

--- a/src/Composite/CompMode.cpp
+++ b/src/Composite/CompMode.cpp
@@ -1,0 +1,123 @@
+/*
+	Author: Martin-Laclaustra 2020
+	License: 
+	Creative Commons Attribution ShareAlike 4.0
+	https://creativecommons.org/licenses/by-sa/4.0/
+	
+	For further details check out: 
+		https://github.com/bitluni
+*/
+#include "CompMode.h"
+
+//ModeComposite arguments order:
+//==============================
+//Horizontal pixels (in order):
+//   hFront,hSync,hBack,hRes,
+//Vertical lines or half-lines (in order):
+//   vFront,vPreEqHL,vSyncHL,vPostEqHL,vBack,vActive,
+//Vertical half-lines specific of odd(first) or even(second) fields:
+//   vOPreRegHL,vOPostRegHL,vEPreRegHL,vEPostRegHL,
+//Vertical resolution reduction:
+//   vDiv,
+//Pixel rate in Hz:
+//   pixelClock,
+//Color encoding data:
+//   burstStart,burstLength,colorClock,phaseAlternating
+//Graphical adjustment of aspect ratio:
+//   aspect
+
+
+//=========
+//PAL MODES
+//=========
+//625 lines/frame, 25 frames/s, h 15.625 kHz, v 50 Hz, visible horizontal proportion 0.812
+
+
+const ModeComposite CompMode::MODEPAL288P(12, 38, 62, 400,  1,  6, 5, 5,  15, 288, 0, 0, 0, 0, 1, 8000000);
+//312 line / 50 frame
+//288 active lines
+
+//125 ns/pix
+//512 pix/line, 64 us/line, 15.625 kHz hSync, 4.75 us hSync
+//312 lines/field-progressiveframe, 19.968 ms/field, 50.080 Hz vSync
+
+
+const ModeComposite CompMode::MODEPAL576I(12, 38, 62, 400,  1,  5, 5, 5,  15, 288, 1, 2, 0, 1, 1, 8000000);
+//625 line / 25 frame
+//576 active lines
+
+// every field has 1 half-line less (vPreEqHL 6->5) and 4 half-lines (1+2+0+1) are added to vsync part
+
+//125 ns/pix
+//512 pix/line, 64 us/line, 15.625 kHz hSync, 4.75 us hSync
+//312.5 lines/field, 20 ms/field, 50 Hz vSync
+
+
+const ModeComposite CompMode::MODEPAL288Pmax(20, 64, 88, 704,  1,  6, 5, 5,  15, 288, 0, 0, 0, 0, 1, 13333333);
+//312 line / 50 frame
+//288 active lines
+
+//75 ns/pix
+//856 pix/line, 64.200 us/line, 15.576324 kHz hSync, 4.8 us hSync
+//312 lines/field-progressiveframe, 20.0304 ms/field, 49.924 Hz vSync
+
+
+const ModeComposite CompMode::MODEPAL288Pmin(2, 5, 5, 52,  1,  6, 5, 5,  15, 288, 0, 0, 0, 0, 1, 1000000);
+//312 line / 50 frame
+//288 active lines
+
+//1000 ns/pix
+//64 pix/line, 64 us/line, 15.625 kHz hSync, 5 us hSync
+//312 lines/field-progressiveframe, 19.968 ms/field, 50.080 Hz vSync
+
+
+const ModeComposite CompMode::MODEPAL576Imin(2, 5, 5, 52,  1,  5, 5, 5,  15, 288, 1, 2, 0, 1, 1, 1000000);
+//625 line / 25 frame
+//576 active lines
+
+//1000 ns/pix
+//64 pix/line, 64 us/line, 15.625 kHz hSync, 5 us hSync
+//312.5 lines/field, 20 ms/field, 50 Hz vSync
+
+
+const ModeComposite CompMode::MODEPAL576Idiv3(12, 38, 62, 400,  1,  5, 5, 5,  15, 288, 1, 2, 0, 1, 3, 8000000);
+//625 line / 25 frame
+//576 active lines
+
+//125 ns/pix
+//512 pix/line, 64 us/line, 15.625 kHz hSync, 4.75 us hSync
+//312.5 lines/field, 20 ms/field, 50 Hz vSync
+
+
+
+//==========
+//NTSC MODES
+//==========
+//525 lines/frame, 30 frames/s, h 15.750 kHz, v 60 Hz, visible horizontal proportion 0.812
+
+
+const ModeComposite CompMode::MODENTSC240P(12, 38, 58, 400,  1,  6, 6, 6,  12, 240, 0, 0, 0, 0, 1, 8000000);
+//262 line / 60 frame
+//240 active lines
+
+//125 ns/pix
+//508 pix/line, 63.5 us/line, 15.74803 kHz hSync, 4.75 us hSync
+//262 lines/field-progressiveframe, 16.637 ms/field, 60.107 Hz vSync
+
+
+const ModeComposite CompMode::MODENTSC480I(12, 38, 58, 400,  1,  6, 6, 6,  12, 240, 0, 0, 1, 1, 1, 8000000);
+//525 line / 30 frame
+//480 active lines
+
+//125 ns/pix
+//508 pix/line, 63.5 us/line, 15.74803 kHz hSync, 4.75 us hSync
+//262.5 lines/field, 16.668750 ms/field, 59.9925 Hz vSync
+
+
+const ModeComposite CompMode::MODENTSC240Pmax(20, 64, 76, 688,  1,  6, 6, 6,  12, 240, 0, 0, 0, 0, 1, 13333333);
+//262 line / 60 frame
+//240 active lines
+
+//75 ns/pix
+//848 pix/line, 63.6 us/line, 15.72327 kHz hSync, 4.8 us hSync
+//262 lines/field-progressiveframe, 16.6632 ms/field, 60.0125 Hz vSync

--- a/src/Composite/CompMode.h
+++ b/src/Composite/CompMode.h
@@ -18,9 +18,11 @@ class CompMode
 
 	static const ModeComposite MODEPAL288P;
 	static const ModeComposite MODEPAL576I;
+	static const ModeComposite MODEPALColor288P;
 
 	static const ModeComposite MODENTSC240P;
 	static const ModeComposite MODENTSC480I;
+	static const ModeComposite MODENTSCColor240P;
 
 	static const ModeComposite MODEPAL288Pmax;
 

--- a/src/Composite/CompMode.h
+++ b/src/Composite/CompMode.h
@@ -1,0 +1,34 @@
+/*
+	Author: Martin-Laclaustra 2020
+	License: 
+	Creative Commons Attribution ShareAlike 4.0
+	https://creativecommons.org/licenses/by-sa/4.0/
+	
+	For further details check out: 
+		https://github.com/bitluni
+*/
+#pragma once
+
+#include "ModeComposite.h"
+
+class CompMode
+{
+  public:
+	CompMode(){};
+
+	static const ModeComposite MODEPAL288P;
+	static const ModeComposite MODEPAL576I;
+
+	static const ModeComposite MODENTSC240P;
+	static const ModeComposite MODENTSC480I;
+
+	static const ModeComposite MODEPAL288Pmax;
+
+	static const ModeComposite MODEPAL288Pmin;
+	static const ModeComposite MODEPAL576Imin;
+
+	static const ModeComposite MODEPAL576Idiv3;
+
+	static const ModeComposite MODENTSC240Pmax;
+};
+

--- a/src/Composite/CompositeColorDAC.h
+++ b/src/Composite/CompositeColorDAC.h
@@ -1,0 +1,418 @@
+/*
+	Author: Martin-Laclaustra 2020
+	License: 
+	Creative Commons Attribution ShareAlike 4.0
+	https://creativecommons.org/licenses/by-sa/4.0/
+	
+	For further details check out: 
+		https://github.com/bitluni
+*/
+
+/*
+	CONNECTION
+	
+	A) voltageDivider = false; B) voltageDivider = true
+	
+	   55 shades                  145 shades
+	
+	ESP32        TV           ESP32                       TV     
+	-----+                     -----+    ____ 100 ohm
+	    G|-                        G|---|____|+          
+	pin25|--------- Comp       pin25|---|____|+--------- Comp    
+	pin26|-                    pin26|-        150 ohm
+	     |                          |
+	     |                          |
+	-----+                     -----+                              
+	
+	Connect pin 25 or 26
+*/
+#pragma once
+#include "Composite.h"
+#include "../Graphics/GraphicsX8CA8Swapped.h"
+
+#include "driver/dac.h"
+
+#include <soc/rtc.h>
+#include <driver/rtc_io.h>
+
+class CompositeColorDAC : public Composite, public GraphicsX8CA8Swapped
+{
+  public:
+	CompositeColorDAC() //DAC based modes only work with I2S0
+		: Composite(0)
+	{
+		lineBufferCount = 3;
+		//Raw DAC output values
+		//---------------------
+		levelHighClipping = 95;
+		levelWhite = 77;
+		amplitudeBurst = 11;
+		levelBlack = 23;
+		levelBlanking = 23;
+		levelLowClipping = 5;
+		levelSync = 0;
+		//Normalized (with voltage divider) DAC output values
+		//---------------------
+		//levelHighClipping = 255;
+		//levelWhite = 207;
+		//amplitudeBurst = 31;
+		//levelBlack = 62;
+		//levelBlanking = 62
+		//levelLowClipping = 14;
+		//levelSync = 0;
+	}
+
+	bool init(const ModeComposite &mode, const int outputPin = 25, const bool voltageDivider = false)
+	{
+		int pinMap[16] = {
+			-1, -1, 
+			-1, -1, -1, -1, -1,
+			-1, -1, -1, -1, -1,
+			-1, -1, -1, -1
+		};
+		this->outputPin = outputPin;
+		this->voltageDivider = voltageDivider;
+		if(voltageDivider)
+		{
+			levelHighClipping = 255;
+			levelWhite = 207;
+			amplitudeBurst = 31;
+			levelBlack = 62;
+			levelBlanking = 62;
+			levelLowClipping = 14;
+			levelSync = 0;
+		}
+		firstPixelOffset = mode.hSync + mode.hBack;
+		colorClockPeriod = (double)mode.pixelClock/mode.colorClock;
+		bufferVDiv = mode.vDiv;
+		bufferInterlaced = mode.interlaced;
+		bufferPhaseAlternating = mode.phaseAlternating;
+		return initDAC(mode, pinMap, 16, -1);
+	}
+
+	bool init(const ModeComposite &mode, const PinConfigComposite &pinConfig)
+	{
+		int pinMap[16] = {
+			-1, -1, 
+			-1, -1, -1, -1, -1,
+			-1, -1, -1, -1, -1,
+			-1, -1, -1, -1
+		};
+		firstPixelOffset = mode.hSync + mode.hBack;
+		colorClockPeriod = (double)mode.pixelClock/mode.colorClock;
+		bufferVDiv = mode.vDiv;
+		bufferInterlaced = mode.interlaced;
+		bufferPhaseAlternating = mode.phaseAlternating;
+		return initDAC(mode, pinMap, 16, -1);
+	}
+
+	bool initDAC(const ModeComposite &mode, const int *pinMap, const int bitCount, const int clockPin)
+	{
+		i2s_dev_t *i2sDevices[] = {&I2S0, &I2S1};
+		this->mode = mode;
+		int xres = mode.hRes;
+		int yres = mode.vRes / mode.vDiv;
+		propagateResolution(xres, yres);
+		totalLines = mode.linesPerFrame;
+		allocateLineBuffers();
+		currentLine = 0;
+		vSyncPassed = false;
+		initParallelOutputMode(pinMap, mode.pixelClock, bitCount, clockPin);
+		volatile i2s_dev_t &i2s = *i2sDevices[i2sIndex];
+		i2s.conf2.lcd_en = 1;
+		i2s.conf.tx_right_first = 1;
+		i2s.conf2.camera_en = 0;
+		dac_i2s_enable();
+		dac_output_enable(outputPin==25?DAC_CHANNEL_1:DAC_CHANNEL_2);
+		startTX();
+		return true;
+	}
+
+	virtual int bytesPerSample() const
+	{
+		return 2;
+	}
+
+	virtual float pixelAspect() const
+	{
+		return 1;
+	}
+
+	virtual void propagateResolution(const int xres, const int yres)
+	{
+		setResolution(xres, yres);
+	}
+
+	int outputPin = 25;
+	bool voltageDivider = false;
+
+	virtual Color **allocateFrameBuffer()
+	{
+		return (Color **)DMABufferDescriptor::allocateDMABufferArray(yres, mode.hRes * bytesPerSample(), true, 0x01000100*levelBlanking);
+	}
+
+	virtual void allocateLineBuffers()
+	{
+		allocateLineBuffers((void **)frameBuffers[0]);
+	}
+
+	//void *hSyncLineBuffer[2];
+
+	void *vBlankLineBuffer[2];
+
+	//Vertical sync
+	//4 possible Half Lines (HL):
+	// NormalFront (NF), NormalBack (NB), Equalizing (EQ), Sync (SY)
+	void *normalFrontLineBuffer;
+	void *equalizingLineBuffer;
+	void *vSyncLineBuffer;
+	void *normalBackLineBuffer;
+
+	//complete ring of buffer descriptors for one frame
+	virtual void allocateLineBuffers(void **frameBuffer)
+	{
+		//lenght of each line
+		int samples = mode.hFront + mode.hSync + mode.hBack + mode.hRes;
+		int bytes = samples * bytesPerSample();
+		int samplesHL = samples/2;
+		int bytesHL = bytes/2;
+		int samplesHSync = mode.hFront + mode.hSync + mode.hBack;
+		int bytesHSync = samplesHSync * bytesPerSample();
+
+		//create and fill the buffers with their default values
+
+		//create the buffers
+		//1 blank prototype line for vFront and vBack
+		vBlankLineBuffer[0] = DMABufferDescriptor::allocateBuffer(bytes, true, 0x01000100*levelBlanking);
+		if(mode.phaseAlternating)
+		{
+			vBlankLineBuffer[1] = DMABufferDescriptor::allocateBuffer(bytes, true, 0x01000100*levelBlanking);
+		} else {
+			vBlankLineBuffer[1] = vBlankLineBuffer[0];
+		}
+		//1 prototype for each HL type in vSync
+		equalizingLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHL, true, 0x01000100*levelBlanking);
+		vSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHL, true, 0x01000100*levelBlanking);
+		normalFrontLineBuffer = vBlankLineBuffer[0];
+		normalBackLineBuffer = (void*)&(((uint8_t*)vBlankLineBuffer[0])[bytesHL]);
+		////1 prototype for hSync
+		//hSyncLineBuffer[0] = DMABufferDescriptor::allocateBuffer(bytesHSync, true, 0x01000100*levelBlanking);
+		//if(mode.phaseAlternating)
+		//{
+			//hSyncLineBuffer[1] = DMABufferDescriptor::allocateBuffer(bytesHSync, true, 0x01000100*levelBlanking);
+		//} else {
+			//hSyncLineBuffer[1] = hSyncLineBuffer[0];
+		//}
+		//n lines as buffer for active lines
+		//already allocated in allocateFrameBuffer
+
+		//fill the buffers with their default values
+		//(bytesPerSample() == 2)(actually only MSByte is used)
+		for (int i = 0; i < samples; i++)
+		{
+			//hsync signal
+			if (i >= mode.hFront && i < (mode.hFront + mode.hSync))
+			{
+				//blank line
+				((unsigned short *)vBlankLineBuffer[0])[i ^ 1] = levelSync << 8;
+				if(mode.phaseAlternating)
+					((unsigned short *)vBlankLineBuffer[1])[i ^ 1] = levelSync << 8;
+				////hsync
+				//((unsigned short *)hSyncLineBuffer[0])[i ^ 1] = levelSync << 8;
+				//if(mode.phaseAlternating)
+					//((unsigned short *)hSyncLineBuffer[1])[i ^ 1] = levelSync << 8;
+			}
+			//color burst // pixel counting starts at the hsync pulse beginning
+			if ( mode.colorClock > 0 &&
+			     i >= (mode.hFront + mode.hSync + mode.burstStart) &&
+			     i < (mode.hFront + mode.hSync + mode.burstStart + mode.burstLength)
+			   )
+			{
+				if(mode.phaseAlternating==false)
+				{
+					//blank line
+					((unsigned short *)vBlankLineBuffer[0])[i ^ 1] =
+					   (unsigned short)(levelBlanking + sin(((double)(i - mode.hFront)/((double)mode.pixelClock/(double)mode.colorClock))*(2*PI) + PI)*amplitudeBurst
+									   ) << 8;
+					////hsync
+					//((unsigned short *)hSyncLineBuffer[0])[i ^ 1] =
+					   //(unsigned short)(levelBlanking + sin(((double)(i - mode.hFront)/((double)mode.pixelClock/(double)mode.colorClock))*(2*PI) + PI)*amplitudeBurst
+									   //) << 8;
+				} else {
+					//blank line
+					((unsigned short *)vBlankLineBuffer[0])[i ^ 1] =
+					   (unsigned short)(levelBlanking + sin(((double)(i - mode.hFront)/((double)mode.pixelClock/(double)mode.colorClock))*(2*PI) + PI*3/4)*amplitudeBurst
+									   ) << 8;
+					((unsigned short *)vBlankLineBuffer[1])[i ^ 1] =
+					   (unsigned short)(levelBlanking + sin(((double)(i - mode.hFront)/((double)mode.pixelClock/(double)mode.colorClock))*(2*PI) - PI*3/4)*amplitudeBurst
+									   ) << 8;
+					////hsync
+					//((unsigned short *)hSyncLineBuffer[0])[i ^ 1] =
+					   //(unsigned short)(levelBlanking + sin(((double)(i - mode.hFront)/((double)mode.pixelClock/(double)mode.colorClock))*(2*PI) + PI*3/4 - PI*3/4)*amplitudeBurst
+									   //) << 8;
+					//((unsigned short *)hSyncLineBuffer[1])[i ^ 1] =
+					   //(unsigned short)(levelBlanking + sin(((double)(i - mode.hFront)/((double)mode.pixelClock/(double)mode.colorClock))*(2*PI) - PI*3/4 - PI*3/4)*amplitudeBurst
+									   //) << 8;
+				}
+			}
+			//equalizing signal
+			if (i >= mode.hFront && i < (mode.hFront + mode.hSync/2))
+			{
+				//equalizing
+				((unsigned short *)equalizingLineBuffer)[i ^ 1] = levelSync << 8;
+			}
+			//vertical sync signal
+			if (i >= mode.hFront && i < (mode.hFront + (samplesHL - mode.hSync)))
+			{
+				//vsync // hFront should never be bigger than hSync or this overflows
+				((unsigned short *)vSyncLineBuffer)[i ^ 1] = levelSync << 8;
+			}
+		}
+
+
+		//allocate DMA buffer descriptors for the whole frame
+		dmaBufferDescriptorCount = mode.linesPerFrame * 2;
+		dmaBufferDescriptors = DMABufferDescriptor::allocateDescriptors(dmaBufferDescriptorCount);
+		//link all buffer descriptors in a ring
+		for (int i = 0; i < dmaBufferDescriptorCount; i++)
+			dmaBufferDescriptors[i].next(dmaBufferDescriptors[(i + 1) % dmaBufferDescriptorCount]);
+
+		//assign the buffers accross the DMA buffer descriptors
+		//CONVENTION: the frame starts after the last non-sync line of previous frame
+		int d = 0;
+		//pre-line
+		int consumelines = mode.vOPreRegHL;
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+		//NF
+		if(consumelines == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+		}
+		//EQ
+		consumelines = mode.vPreEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//SY
+		consumelines = mode.vSyncHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(vSyncLineBuffer, bytesHL);
+		//EQ
+		consumelines = mode.vPostEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//NB
+		consumelines = mode.vOPostRegHL;
+		if(consumelines & 1 == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines--;
+		}
+		//post-line
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+
+		for (int i = 0; i < mode.vBack; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+		for (int i = 0; i < mode.vActive; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHSync);
+			dmaBufferDescriptors[d++].setBuffer(frameBuffer[(i*(mode.interlaced?2:1) - (mode.interlaced?1:0)) / mode.vDiv], mode.hRes * bytesPerSample());
+		}
+		for (int i = 0; i < mode.vFront; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+
+		// here d should be linesPerFrame*2 if mode is progressive
+		// and linesPerFrame*2 / 2 if mode is interlaced
+		if(mode.interlaced)
+		{
+
+		//pre-line
+		int consumelines = mode.vEPreRegHL;
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+		//NF
+		if(consumelines == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+		}
+		//EQ
+		consumelines = mode.vPreEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//SY
+		consumelines = mode.vSyncHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(vSyncLineBuffer, bytesHL);
+		//EQ
+		consumelines = mode.vPostEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//NB
+		consumelines = mode.vEPostRegHL;
+		if(consumelines & 1 == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines--;
+		}
+		//post-line
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+
+		for (int i = 0; i < mode.vBack; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vBlankLineBuffer[(d/2)&1], bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+		for (int i = 0; i < mode.vActive; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vBlankLineBuffer[(d/2)&1], bytesHSync);
+			dmaBufferDescriptors[d++].setBuffer(frameBuffer[(i*2) / mode.vDiv], mode.hRes * bytesPerSample());
+		}
+		for (int i = 0; i < mode.vFront; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+
+		}
+	}
+
+	virtual void show(bool vSync = false)
+	{
+		if (!frameBufferCount)
+			return;
+		if (vSync)
+		{
+			//TODO read the I2S docs to find out
+		}
+		Graphics::show(vSync);
+	}
+
+  protected:
+	virtual void interrupt()
+	{
+	}
+};

--- a/src/Composite/CompositeColorLadder.h
+++ b/src/Composite/CompositeColorLadder.h
@@ -1,0 +1,388 @@
+/*
+	Author: Martin-Laclaustra 2020
+	License: 
+	Creative Commons Attribution ShareAlike 4.0
+	https://creativecommons.org/licenses/by-sa/4.0/
+	
+	For further details check out: 
+		https://github.com/bitluni
+*/
+
+/*
+	CONNECTION
+	
+	A) R-2R resistor ladder; B) unequal rungs ladder
+	
+	   55 shades                  up to 254 shades?
+	
+	ESP32        TV           ESP32                       TV
+	-----+                    -----+    ____ 
+	    G|-+_____                 G|---|____|
+	pinA0|-| R2R |- Comp      pinA0|---|____|+--------- Comp
+	pinA1|-|     |            pinA1|---|____|
+	pinA2|-|     |              ...|
+	  ...|-|_____|                 |
+	-----+                    -----+
+	
+	Connect pins of your choice (A0...A8=any pins).
+	Custom ladders can be used by tweaking output levels member variables
+*/
+#pragma once
+#include "Composite.h"
+#include "../Graphics/GraphicsCA8Swapped.h"
+
+class CompositeColorLadder : public Composite, public GraphicsCA8Swapped
+{
+  public:
+	CompositeColorLadder() //8 bit based modes only work with I2S1
+		: Composite(1)
+	{
+		lineBufferCount = 3;
+		//Raw DAC output values
+		//---------------------
+		//levelHighClipping = 95;
+		//levelWhite = 77;
+		//amplitudeBurst = 11;
+		//levelBlack = 23;
+		//levelBlanking = 23;
+		//levelLowClipping = 5;
+		//levelSync = 0;
+		//Normalized (with voltage divider) DAC output values
+		//---------------------
+		levelHighClipping = 255;
+		levelWhite = 207;
+		amplitudeBurst = 31;
+		levelBlack = 62;
+		levelBlanking = 62;
+		levelLowClipping = 14;
+		levelSync = 0;
+	}
+
+	bool init(const ModeComposite &mode, 
+			  const int C0Pin, const int C1Pin,
+			  const int C2Pin, const int C3Pin,
+			  const int C4Pin, const int C5Pin,
+			  const int C6Pin, const int C7Pin)
+	{
+		int pinMap[8] = {
+			C0Pin, C1Pin,
+			C2Pin, C3Pin,
+			C4Pin, C5Pin,
+			C6Pin, C7Pin
+		};
+
+		firstPixelOffset = mode.hSync + mode.hBack;
+		colorClockPeriod = (double)mode.pixelClock/mode.colorClock;
+		bufferVDiv = mode.vDiv;
+		bufferInterlaced = mode.interlaced;
+		bufferPhaseAlternating = mode.phaseAlternating;
+		return Composite::init(mode, pinMap, 8);
+	}
+
+	bool init(const ModeComposite &mode, const int *compositePins)
+	{
+		firstPixelOffset = mode.hSync + mode.hBack;
+		colorClockPeriod = (double)mode.pixelClock/mode.colorClock;
+		bufferVDiv = mode.vDiv;
+		bufferInterlaced = mode.interlaced;
+		bufferPhaseAlternating = mode.phaseAlternating;
+		return Composite::init(mode, compositePins, 8);
+	}
+
+	bool init(const ModeComposite &mode, const PinConfigComposite &pinConfig)
+	{
+		firstPixelOffset = mode.hSync + mode.hBack;
+		colorClockPeriod = (double)mode.pixelClock/mode.colorClock;
+		bufferVDiv = mode.vDiv;
+		bufferInterlaced = mode.interlaced;
+		bufferPhaseAlternating = mode.phaseAlternating;
+		int pins[8];
+		pinConfig.fill(pins);
+		return Composite::init(mode, pins, 8);
+	}
+
+	virtual int bytesPerSample() const
+	{
+		return 1;
+	}
+
+	virtual float pixelAspect() const
+	{
+		return 1;
+	}
+
+	virtual void propagateResolution(const int xres, const int yres)
+	{
+		setResolution(xres, yres);
+	}
+
+	virtual Color **allocateFrameBuffer()
+	{
+		return (Color **)DMABufferDescriptor::allocateDMABufferArray(yres, mode.hRes * bytesPerSample(), true, 0x01010101*levelBlanking);
+	}
+
+	virtual void allocateLineBuffers()
+	{
+		allocateLineBuffers((void **)frameBuffers[0]);
+	}
+
+	//void *hSyncLineBuffer[2];
+
+	void *vBlankLineBuffer[2];
+
+	//Vertical sync
+	//4 possible Half Lines (HL):
+	// NormalFront (NF), NormalBack (NB), Equalizing (EQ), Sync (SY)
+	void *normalFrontLineBuffer;
+	void *equalizingLineBuffer;
+	void *vSyncLineBuffer;
+	void *normalBackLineBuffer;
+
+	//complete ring of buffer descriptors for one frame
+	virtual void allocateLineBuffers(void **frameBuffer)
+	{
+		//lenght of each line
+		int samples = mode.hFront + mode.hSync + mode.hBack + mode.hRes;
+		int bytes = samples * bytesPerSample();
+		int samplesHL = samples/2;
+		int bytesHL = bytes/2;
+		int samplesHSync = mode.hFront + mode.hSync + mode.hBack;
+		int bytesHSync = samplesHSync * bytesPerSample();
+
+		//create and fill the buffers with their default values
+
+		//create the buffers
+		//1 blank prototype line for vFront and vBack
+		vBlankLineBuffer[0] = DMABufferDescriptor::allocateBuffer(bytes, true, 0x01010101*levelBlanking);
+		if(mode.phaseAlternating)
+		{
+			vBlankLineBuffer[1] = DMABufferDescriptor::allocateBuffer(bytes, true, 0x01010101*levelBlanking);
+		} else {
+			vBlankLineBuffer[1] = vBlankLineBuffer[0];
+		}
+		//1 prototype for each HL type in vSync
+		equalizingLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHL, true, 0x01010101*levelBlanking);
+		vSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHL, true, 0x01010101*levelBlanking);
+		normalFrontLineBuffer = vBlankLineBuffer[0];
+		normalBackLineBuffer = (void*)&(((uint8_t*)vBlankLineBuffer[0])[bytesHL]);
+		////1 prototype for hSync
+		//hSyncLineBuffer[0] = DMABufferDescriptor::allocateBuffer(bytesHSync, true, 0x01010101*levelBlanking);
+		//if(mode.phaseAlternating)
+		//{
+			//hSyncLineBuffer[1] = DMABufferDescriptor::allocateBuffer(bytesHSync, true, 0x01010101*levelBlanking);
+		//} else {
+			//hSyncLineBuffer[1] = hSyncLineBuffer[0];
+		//}
+		//n lines as buffer for active lines
+		//already allocated in allocateFrameBuffer
+
+		//fill the buffers with their default values
+		//(bytesPerSample() == 2)(actually only MSByte is used)
+		for (int i = 0; i < samples; i++)
+		{
+			//hsync signal
+			if (i >= mode.hFront && i < (mode.hFront + mode.hSync))
+			{
+				//blank line
+				((unsigned char *)vBlankLineBuffer[0])[i ^ 2] = levelSync;
+				if(mode.phaseAlternating)
+					((unsigned char *)vBlankLineBuffer[1])[i ^ 2] = levelSync;
+				////hsync
+				//((unsigned char *)hSyncLineBuffer[0])[i ^ 2] = levelSync;
+				//if(mode.phaseAlternating)
+					//((unsigned char *)hSyncLineBuffer[1])[i ^ 2] = levelSync;
+			}
+			//color burst // pixel counting starts at the hsync pulse beginning
+			if ( mode.colorClock > 0 &&
+			     i >= (mode.hFront + mode.hSync + mode.burstStart) &&
+			     i < (mode.hFront + mode.hSync + mode.burstStart + mode.burstLength)
+			   )
+			{
+				if(mode.phaseAlternating==false)
+				{
+					//blank line
+					((unsigned char *)vBlankLineBuffer[0])[i ^ 2] =
+					   (unsigned char)(levelBlanking + sin(((double)(i - mode.hFront)/((double)mode.pixelClock/(double)mode.colorClock))*(2*PI) + PI)*amplitudeBurst
+									   );
+					////hsync
+					//((unsigned char *)hSyncLineBuffer[0])[i ^ 2] =
+					   //(unsigned char)(levelBlanking + sin(((double)(i - mode.hFront)/((double)mode.pixelClock/(double)mode.colorClock))*(2*PI) + PI)*amplitudeBurst
+									   //);
+				} else {
+					//blank line
+					((unsigned char *)vBlankLineBuffer[0])[i ^ 2] =
+					   (unsigned char)(levelBlanking + sin(((double)(i - mode.hFront)/((double)mode.pixelClock/(double)mode.colorClock))*(2*PI) + PI*3/4)*amplitudeBurst
+									   );
+					((unsigned char *)vBlankLineBuffer[1])[i ^ 2] =
+					   (unsigned char)(levelBlanking + sin(((double)(i - mode.hFront)/((double)mode.pixelClock/(double)mode.colorClock))*(2*PI) - PI*3/4)*amplitudeBurst
+									   );
+					////hsync
+					//((unsigned char *)hSyncLineBuffer[0])[i ^ 2] =
+					   //(unsigned char)(levelBlanking + sin(((double)(i - mode.hFront)/((double)mode.pixelClock/(double)mode.colorClock))*(2*PI) + PI*3/4 - PI*3/4)*amplitudeBurst
+									   //);
+					//((unsigned char *)hSyncLineBuffer[1])[i ^ 2] =
+					   //(unsigned char)(levelBlanking + sin(((double)(i - mode.hFront)/((double)mode.pixelClock/(double)mode.colorClock))*(2*PI) - PI*3/4 - PI*3/4)*amplitudeBurst
+									   //);
+				}
+			}
+			//equalizing signal
+			if (i >= mode.hFront && i < (mode.hFront + mode.hSync/2))
+			{
+				//equalizing
+				((unsigned char *)equalizingLineBuffer)[i ^ 1] = levelSync;
+			}
+			//vertical sync signal
+			if (i >= mode.hFront && i < (mode.hFront + (samplesHL - mode.hSync)))
+			{
+				//vsync // hFront should never be bigger than hSync or this overflows
+				((unsigned char *)vSyncLineBuffer)[i ^ 1] = levelSync;
+			}
+		}
+
+
+		//allocate DMA buffer descriptors for the whole frame
+		dmaBufferDescriptorCount = mode.linesPerFrame * 2;
+		dmaBufferDescriptors = DMABufferDescriptor::allocateDescriptors(dmaBufferDescriptorCount);
+		//link all buffer descriptors in a ring
+		for (int i = 0; i < dmaBufferDescriptorCount; i++)
+			dmaBufferDescriptors[i].next(dmaBufferDescriptors[(i + 1) % dmaBufferDescriptorCount]);
+
+		//assign the buffers accross the DMA buffer descriptors
+		//CONVENTION: the frame starts after the last non-sync line of previous frame
+		int d = 0;
+		//pre-line
+		int consumelines = mode.vOPreRegHL;
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+		//NF
+		if(consumelines == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+		}
+		//EQ
+		consumelines = mode.vPreEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//SY
+		consumelines = mode.vSyncHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(vSyncLineBuffer, bytesHL);
+		//EQ
+		consumelines = mode.vPostEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//NB
+		consumelines = mode.vOPostRegHL;
+		if(consumelines & 1 == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines--;
+		}
+		//post-line
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+
+		for (int i = 0; i < mode.vBack; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+		for (int i = 0; i < mode.vActive; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHSync);
+			dmaBufferDescriptors[d++].setBuffer(frameBuffer[(i*(mode.interlaced?2:1) - (mode.interlaced?1:0)) / mode.vDiv], mode.hRes * bytesPerSample());
+		}
+		for (int i = 0; i < mode.vFront; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+
+		// here d should be linesPerFrame*2 if mode is progressive
+		// and linesPerFrame*2 / 2 if mode is interlaced
+		if(mode.interlaced)
+		{
+
+		//pre-line
+		int consumelines = mode.vEPreRegHL;
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+		//NF
+		if(consumelines == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+		}
+		//EQ
+		consumelines = mode.vPreEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//SY
+		consumelines = mode.vSyncHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(vSyncLineBuffer, bytesHL);
+		//EQ
+		consumelines = mode.vPostEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//NB
+		consumelines = mode.vEPostRegHL;
+		if(consumelines & 1 == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines--;
+		}
+		//post-line
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+
+		for (int i = 0; i < mode.vBack; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vBlankLineBuffer[(d/2)&1], bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+		for (int i = 0; i < mode.vActive; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(vBlankLineBuffer[(d/2)&1], bytesHSync);
+			dmaBufferDescriptors[d++].setBuffer(frameBuffer[(i*2) / mode.vDiv], mode.hRes * bytesPerSample());
+		}
+		for (int i = 0; i < mode.vFront; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+
+		}
+	}
+
+	virtual void show(bool vSync = false)
+	{
+		if (!frameBufferCount)
+			return;
+		if (vSync)
+		{
+			//TODO read the I2S docs to find out
+		}
+		Graphics::show(vSync);
+	}
+
+  protected:
+	virtual void interrupt()
+	{
+	}
+};

--- a/src/Composite/CompositeGrayDAC.h
+++ b/src/Composite/CompositeGrayDAC.h
@@ -1,0 +1,343 @@
+/*
+	Author: Martin-Laclaustra 2020
+	License: 
+	Creative Commons Attribution ShareAlike 4.0
+	https://creativecommons.org/licenses/by-sa/4.0/
+	
+	For further details check out: 
+		https://github.com/bitluni
+*/
+
+/*
+	CONNECTION
+	
+	A) voltageDivider = false; B) voltageDivider = true
+	
+	   55 shades                  179 shades
+	
+	ESP32        TV           ESP32                       TV     
+	-----+                     -----+    ____ 100 ohm
+	    G|-                        G|---|____|+          
+	pin25|--------- Comp       pin25|---|____|+--------- Comp    
+	pin26|-                    pin26|-        220 ohm
+	     |                          |
+	     |                          |
+	-----+                     -----+                              
+	
+	Connect pin 25 or 26
+*/
+#pragma once
+#include "Composite.h"
+#include "../Graphics/GraphicsX6S2W8Swapped.h"
+
+#include "driver/dac.h"
+
+#include <soc/rtc.h>
+#include <driver/rtc_io.h>
+
+class CompositeGrayDAC : public Composite, public GraphicsX6S2W8Swapped
+{
+  public:
+	CompositeGrayDAC() //DAC based modes only work with I2S0
+		: Composite(0)
+	{
+		lineBufferCount = 3;
+		colorMinValue = 23;
+		syncLevel = 0;
+		colorMaxValue = 77;
+	}
+
+	bool init(const ModeComposite &mode, const int outputPin = 25, const bool voltageDivider = false)
+	{
+		int pinMap[16] = {
+			-1, -1, 
+			-1, -1, -1, -1, -1,
+			-1, -1, -1, -1, -1,
+			-1, -1, -1, -1
+		};
+		this->outputPin = outputPin;
+		this->voltageDivider = voltageDivider;
+		if(voltageDivider)
+		{
+			colorMinValue = 77;
+			syncLevel = 0;
+			colorMaxValue = 255;
+		}
+		//values must be shifted to the MSByte to be output
+		//which is equivalent to multiplying by 256
+		//instead of shifting, do not divide here:
+		//colorDepthConversionFactor = (colorMaxValue - colorMinValue + 1)/256;
+		colorDepthConversionFactor = colorMaxValue - colorMinValue + 1;
+		return initDAC(mode, pinMap, 16, -1);
+	}
+
+	bool init(const ModeComposite &mode, const PinConfigComposite &pinConfig)
+	{
+		int pinMap[16] = {
+			-1, -1, 
+			-1, -1, -1, -1, -1,
+			-1, -1, -1, -1, -1,
+			-1, -1, -1, -1
+		};
+		colorDepthConversionFactor = colorMaxValue - colorMinValue + 1;
+		return initDAC(mode, pinMap, 16, -1);
+	}
+
+	bool initDAC(const ModeComposite &mode, const int *pinMap, const int bitCount, const int clockPin)
+	{
+		i2s_dev_t *i2sDevices[] = {&I2S0, &I2S1};
+		this->mode = mode;
+		int xres = mode.hRes;
+		int yres = mode.vRes / mode.vDiv;
+		propagateResolution(xres, yres);
+		totalLines = mode.linesPerFrame;
+		allocateLineBuffers();
+		currentLine = 0;
+		vSyncPassed = false;
+		initParallelOutputMode(pinMap, mode.pixelClock, bitCount, clockPin);
+		volatile i2s_dev_t &i2s = *i2sDevices[i2sIndex];
+		i2s.conf2.lcd_en = 1;
+		i2s.conf.tx_right_first = 1;
+		i2s.conf2.camera_en = 0;
+		dac_i2s_enable();
+		dac_output_enable(outputPin==25?DAC_CHANNEL_1:DAC_CHANNEL_2);
+		startTX();
+		return true;
+	}
+
+	virtual int bytesPerSample() const
+	{
+		return 2;
+	}
+
+	virtual float pixelAspect() const
+	{
+		return 1;
+	}
+
+	virtual void propagateResolution(const int xres, const int yres)
+	{
+		setResolution(xres, yres);
+	}
+
+	int outputPin = 25;
+	bool voltageDivider = false;
+
+	virtual Color **allocateFrameBuffer()
+	{
+		return (Color **)DMABufferDescriptor::allocateDMABufferArray(yres, mode.hRes * bytesPerSample(), true, 0x01000100*colorMinValue);
+	}
+
+	virtual void allocateLineBuffers()
+	{
+		allocateLineBuffers((void **)frameBuffers[0]);
+	}
+
+	void *hSyncLineBuffer;
+
+	void *vBlankLineBuffer;
+
+	//Vertical sync
+	//4 possible Half Lines (HL):
+	// NormalFront (NF), NormalBack (NB), Equalizing (EQ), Sync (SY)
+	void *normalFrontLineBuffer;
+	void *equalizingLineBuffer;
+	void *vSyncLineBuffer;
+	void *normalBackLineBuffer;
+
+	//complete ring of buffer descriptors for one frame
+	virtual void allocateLineBuffers(void **frameBuffer)
+	{
+		//lenght of each line
+		int samples = mode.hFront + mode.hSync + mode.hBack + mode.hRes;
+		int bytes = samples * bytesPerSample();
+		int samplesHL = samples/2;
+		int bytesHL = bytes/2;
+		int samplesHSync = mode.hFront + mode.hSync + mode.hBack;
+		int bytesHSync = samplesHSync * bytesPerSample();
+
+		//create and fill the buffers with their default values
+
+		//create the buffers
+		//1 blank prototype line for vFront and vBack
+		vBlankLineBuffer = DMABufferDescriptor::allocateBuffer(bytes, true, 0x01000100*colorMinValue);
+		//1 prototype for each HL type in vSync
+		equalizingLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHL, true, 0x01000100*colorMinValue);
+		vSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHL, true, 0x01000100*colorMinValue);
+		normalFrontLineBuffer = vBlankLineBuffer;
+		normalBackLineBuffer = (void*)&(((uint8_t*)vBlankLineBuffer)[bytesHL]);
+		//1 prototype for hSync
+		hSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHSync, true, 0x01000100*colorMinValue);
+		//n lines as buffer for active lines
+		//already allocated in allocateFrameBuffer
+
+		//fill the buffers with their default values
+		//(bytesPerSample() == 2)(actually only MSByte is used)
+		for (int i = 0; i < samples; i++)
+		{
+			if (i >= mode.hFront && i < (mode.hFront + mode.hSync))
+			{
+				//blank line
+				((unsigned short *)vBlankLineBuffer)[i ^ 1] = syncLevel << 8;
+				//hsync
+				((unsigned short *)hSyncLineBuffer)[i ^ 1] = syncLevel << 8;
+			}
+			if (i >= mode.hFront && i < (mode.hFront + mode.hSync/2))
+			{
+				//equalizing
+				((unsigned short *)equalizingLineBuffer)[i ^ 1] = syncLevel << 8;
+			}
+			if (i >= mode.hFront && i < (mode.hFront + (samplesHL - mode.hSync)))
+			{
+				//vsync // hFront should never be bigger than hSync or this overflows
+				((unsigned short *)vSyncLineBuffer)[i ^ 1] = syncLevel << 8;
+			}
+		}
+
+
+		//allocate DMA buffer descriptors for the whole frame
+		dmaBufferDescriptorCount = mode.linesPerFrame * 2;
+		dmaBufferDescriptors = DMABufferDescriptor::allocateDescriptors(dmaBufferDescriptorCount);
+		//link all buffer descriptors in a ring
+		for (int i = 0; i < dmaBufferDescriptorCount; i++)
+			dmaBufferDescriptors[i].next(dmaBufferDescriptors[(i + 1) % dmaBufferDescriptorCount]);
+
+		//assign the buffers accross the DMA buffer descriptors
+		//CONVENTION: the frame starts after the last non-sync line of previous frame
+		int d = 0;
+		//pre-line
+		int consumelines = mode.vOPreRegHL;
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+		//NF
+		if(consumelines == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+		}
+		//EQ
+		consumelines = mode.vPreEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//SY
+		consumelines = mode.vSyncHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(vSyncLineBuffer, bytesHL);
+		//EQ
+		consumelines = mode.vPostEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//NB
+		consumelines = mode.vOPostRegHL;
+		if(consumelines & 1 == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines--;
+		}
+		//post-line
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+
+		for (int i = 0; i < mode.vBack; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+		for (int i = 0; i < mode.vActive; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHSync);
+			dmaBufferDescriptors[d++].setBuffer(frameBuffer[(i*(mode.interlaced?2:1) - (mode.interlaced?1:0)) / mode.vDiv], mode.hRes * bytesPerSample());
+		}
+		for (int i = 0; i < mode.vFront; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+
+		// here d should be linesPerFrame*2 if mode is progressive
+		// and linesPerFrame*2 / 2 if mode is interlaced
+		if(mode.interlaced)
+		{
+
+		//pre-line
+		int consumelines = mode.vEPreRegHL;
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+		//NF
+		if(consumelines == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+		}
+		//EQ
+		consumelines = mode.vPreEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//SY
+		consumelines = mode.vSyncHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(vSyncLineBuffer, bytesHL);
+		//EQ
+		consumelines = mode.vPostEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//NB
+		consumelines = mode.vEPostRegHL;
+		if(consumelines & 1 == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines--;
+		}
+		//post-line
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+
+		for (int i = 0; i < mode.vBack; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+		for (int i = 0; i < mode.vActive; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHSync);
+			dmaBufferDescriptors[d++].setBuffer(frameBuffer[(i*2) / mode.vDiv], mode.hRes * bytesPerSample());
+		}
+		for (int i = 0; i < mode.vFront; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+
+		}
+	}
+
+	virtual void show(bool vSync = false)
+	{
+		if (!frameBufferCount)
+			return;
+		if (vSync)
+		{
+			//TODO read the I2S docs to find out
+		}
+		Graphics::show(vSync);
+	}
+
+  protected:
+	virtual void interrupt()
+	{
+	}
+};

--- a/src/Composite/CompositeGrayLadder.h
+++ b/src/Composite/CompositeGrayLadder.h
@@ -129,14 +129,14 @@ class CompositeGrayLadder : public Composite, public GraphicsW8RangedSwapped
 
 		//create the buffers
 		//1 blank prototype line for vFront and vBack
-		vBlankLineBuffer = DMABufferDescriptor::allocateBuffer(bytes, true, 0x01000100*colorMinValue);
+		vBlankLineBuffer = DMABufferDescriptor::allocateBuffer(bytes, true, 0x01010101*colorMinValue);
 		//1 prototype for each HL type in vSync
-		equalizingLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHL, true, 0x01000100*colorMinValue);
-		vSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHL, true, 0x01000100*colorMinValue);
+		equalizingLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHL, true, 0x01010101*colorMinValue);
+		vSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHL, true, 0x01010101*colorMinValue);
 		normalFrontLineBuffer = vBlankLineBuffer;
 		normalBackLineBuffer = (void*)&(((uint8_t*)vBlankLineBuffer)[bytesHL]);
 		//1 prototype for hSync
-		hSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHSync, true, 0x01000100*colorMinValue);
+		hSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHSync, true, 0x01010101*colorMinValue);
 		//n lines as buffer for active lines
 		//already allocated in allocateFrameBuffer
 
@@ -147,19 +147,19 @@ class CompositeGrayLadder : public Composite, public GraphicsW8RangedSwapped
 			if (i >= mode.hFront && i < (mode.hFront + mode.hSync))
 			{
 				//blank line
-				((unsigned char *)vBlankLineBuffer)[i ^ 1] = syncLevel << 8;
+				((unsigned char *)vBlankLineBuffer)[i ^ 2] = syncLevel;
 				//hsync
-				((unsigned char *)hSyncLineBuffer)[i ^ 1] = syncLevel << 8;
+				((unsigned char *)hSyncLineBuffer)[i ^ 2] = syncLevel;
 			}
 			if (i >= mode.hFront && i < (mode.hFront + mode.hSync/2))
 			{
 				//equalizing
-				((unsigned char *)equalizingLineBuffer)[i ^ 1] = syncLevel << 8;
+				((unsigned char *)equalizingLineBuffer)[i ^ 2] = syncLevel;
 			}
 			if (i >= mode.hFront && i < (mode.hFront + (samplesHL - mode.hSync)))
 			{
 				//vsync // hFront should never be bigger than hSync or this overflows
-				((unsigned char *)vSyncLineBuffer)[i ^ 1] = syncLevel << 8;
+				((unsigned char *)vSyncLineBuffer)[i ^ 2] = syncLevel;
 			}
 		}
 

--- a/src/Composite/CompositeGrayLadder.h
+++ b/src/Composite/CompositeGrayLadder.h
@@ -1,0 +1,322 @@
+/*
+	Author: Martin-Laclaustra 2020
+	License: 
+	Creative Commons Attribution ShareAlike 4.0
+	https://creativecommons.org/licenses/by-sa/4.0/
+	
+	For further details check out: 
+		https://github.com/bitluni
+*/
+
+/*
+	CONNECTION
+	
+	A) R–2R resistor ladder; B) unequal rungs ladder
+	
+	   55 shades                  up to 254 shades?
+	
+	ESP32        TV           ESP32                       TV
+	-----+                    -----+    ____ 
+	    G|-+_____                 G|---|____|
+	pinA0|-| R2R |- Comp      pinA0|---|____|+--------- Comp
+	pinA1|-|     |            pinA1|---|____|
+	pinA2|-|     |              ...|
+	  ...|-|_____|                 |
+	-----+                    -----+
+	
+	Connect pins of your choice (A0...A8=any pins).
+	Custom ladders can be used by tweaking colorMinValue and colorMaxValue
+*/
+#pragma once
+#include "Composite.h"
+#include "../Graphics/GraphicsW8RangedSwapped.h"
+
+class CompositeGrayLadder : public Composite, public GraphicsW8RangedSwapped
+{
+  public:
+	CompositeGrayLadder() //8 bit based modes only work with I2S1
+		: Composite(1)
+	{
+		colorMinValue = 76;
+		syncLevel = 0;
+		colorMaxValue = 255;
+	}
+
+
+	bool init(const ModeComposite &mode, 
+			  const int C0Pin, const int C1Pin,
+			  const int C2Pin, const int C3Pin,
+			  const int C4Pin, const int C5Pin,
+			  const int C6Pin, const int C7Pin)
+	{
+		int pinMap[8] = {
+			C0Pin, C1Pin,
+			C2Pin, C3Pin,
+			C4Pin, C5Pin,
+			C6Pin, C7Pin
+		};
+
+		//values must be divided to fit 8bits
+		//instead of using a float, bitshift 8 bits to the right later:
+		//colorDepthConversionFactor = (colorMaxValue - colorMinValue + 1)/256;
+		colorDepthConversionFactor = colorMaxValue - colorMinValue + 1;
+		return Composite::init(mode, pinMap, 8);
+	}
+
+	bool init(const ModeComposite &mode, const int *compositePins)
+	{
+		colorDepthConversionFactor = colorMaxValue - colorMinValue + 1;
+		return Composite::init(mode, compositePins, 8);
+	}
+
+	bool init(const ModeComposite &mode, const PinConfigComposite &pinConfig)
+	{
+		colorDepthConversionFactor = colorMaxValue - colorMinValue + 1;
+		int pins[8];
+		pinConfig.fill(pins);
+		return Composite::init(mode, pins, 8);
+	}
+
+	virtual int bytesPerSample() const
+	{
+		return 1;
+	}
+
+	virtual float pixelAspect() const
+	{
+		return 1;
+	}
+
+	virtual void propagateResolution(const int xres, const int yres)
+	{
+		setResolution(xres, yres);
+	}
+
+	virtual Color **allocateFrameBuffer()
+	{
+		return (Color **)DMABufferDescriptor::allocateDMABufferArray(yres, mode.hRes * bytesPerSample(), true, 0x01010101*colorMinValue);
+	}
+
+	virtual void allocateLineBuffers()
+	{
+		allocateLineBuffers((void **)frameBuffers[0]);
+	}
+
+	void *hSyncLineBuffer;
+
+	void *vBlankLineBuffer;
+
+	//Vertical sync
+	//4 possible Half Lines (HL):
+	// NormalFront (NF), NormalBack (NB), Equalizing (EQ), Sync (SY)
+	void *normalFrontLineBuffer;
+	void *equalizingLineBuffer;
+	void *vSyncLineBuffer;
+	void *normalBackLineBuffer;
+
+	//complete ring of buffer descriptors for one frame
+	virtual void allocateLineBuffers(void **frameBuffer)
+	{
+		//lenght of each line
+		int samples = mode.hFront + mode.hSync + mode.hBack + mode.hRes;
+		int bytes = samples * bytesPerSample();
+		int samplesHL = samples/2;
+		int bytesHL = bytes/2;
+		int samplesHSync = mode.hFront + mode.hSync + mode.hBack;
+		int bytesHSync = samplesHSync * bytesPerSample();
+
+		//create and fill the buffers with their default values
+
+		//create the buffers
+		//1 blank prototype line for vFront and vBack
+		vBlankLineBuffer = DMABufferDescriptor::allocateBuffer(bytes, true, 0x01000100*colorMinValue);
+		//1 prototype for each HL type in vSync
+		equalizingLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHL, true, 0x01000100*colorMinValue);
+		vSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHL, true, 0x01000100*colorMinValue);
+		normalFrontLineBuffer = vBlankLineBuffer;
+		normalBackLineBuffer = (void*)&(((uint8_t*)vBlankLineBuffer)[bytesHL]);
+		//1 prototype for hSync
+		hSyncLineBuffer = DMABufferDescriptor::allocateBuffer(bytesHSync, true, 0x01000100*colorMinValue);
+		//n lines as buffer for active lines
+		//already allocated in allocateFrameBuffer
+
+		//fill the buffers with their default values
+		//(bytesPerSample() == 2)(actually only MSByte is used)
+		for (int i = 0; i < samples; i++)
+		{
+			if (i >= mode.hFront && i < (mode.hFront + mode.hSync))
+			{
+				//blank line
+				((unsigned char *)vBlankLineBuffer)[i ^ 1] = syncLevel << 8;
+				//hsync
+				((unsigned char *)hSyncLineBuffer)[i ^ 1] = syncLevel << 8;
+			}
+			if (i >= mode.hFront && i < (mode.hFront + mode.hSync/2))
+			{
+				//equalizing
+				((unsigned char *)equalizingLineBuffer)[i ^ 1] = syncLevel << 8;
+			}
+			if (i >= mode.hFront && i < (mode.hFront + (samplesHL - mode.hSync)))
+			{
+				//vsync // hFront should never be bigger than hSync or this overflows
+				((unsigned char *)vSyncLineBuffer)[i ^ 1] = syncLevel << 8;
+			}
+		}
+
+
+		//allocate DMA buffer descriptors for the whole frame
+		dmaBufferDescriptorCount = mode.linesPerFrame * 2;
+		dmaBufferDescriptors = DMABufferDescriptor::allocateDescriptors(dmaBufferDescriptorCount);
+		//link all buffer descriptors in a ring
+		for (int i = 0; i < dmaBufferDescriptorCount; i++)
+			dmaBufferDescriptors[i].next(dmaBufferDescriptors[(i + 1) % dmaBufferDescriptorCount]);
+
+		//assign the buffers accross the DMA buffer descriptors
+		//CONVENTION: the frame starts after the last non-sync line of previous frame
+		int d = 0;
+		//pre-line
+		int consumelines = mode.vOPreRegHL;
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+		//NF
+		if(consumelines == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+		}
+		//EQ
+		consumelines = mode.vPreEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//SY
+		consumelines = mode.vSyncHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(vSyncLineBuffer, bytesHL);
+		//EQ
+		consumelines = mode.vPostEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//NB
+		consumelines = mode.vOPostRegHL;
+		if(consumelines & 1 == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines--;
+		}
+		//post-line
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+
+		for (int i = 0; i < mode.vBack; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+		for (int i = 0; i < mode.vActive; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHSync);
+			dmaBufferDescriptors[d++].setBuffer(frameBuffer[(i*(mode.interlaced?2:1) - (mode.interlaced?1:0)) / mode.vDiv], mode.hRes * bytesPerSample());
+		}
+		for (int i = 0; i < mode.vFront; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+
+		// here d should be linesPerFrame*2 if mode is progressive
+		// and linesPerFrame*2 / 2 if mode is interlaced
+		if(mode.interlaced)
+		{
+
+		//pre-line
+		int consumelines = mode.vEPreRegHL;
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+		//NF
+		if(consumelines == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+		}
+		//EQ
+		consumelines = mode.vPreEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//SY
+		consumelines = mode.vSyncHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(vSyncLineBuffer, bytesHL);
+		//EQ
+		consumelines = mode.vPostEqHL;
+		for (int i = 0; i < consumelines; i++)
+			dmaBufferDescriptors[d++].setBuffer(equalizingLineBuffer, bytesHL);
+		//NB
+		consumelines = mode.vEPostRegHL;
+		if(consumelines & 1 == 1)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines--;
+		}
+		//post-line
+		while(consumelines>=2)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+			consumelines-=2;
+		}
+
+		for (int i = 0; i < mode.vBack; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+		for (int i = 0; i < mode.vActive; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHSync);
+			dmaBufferDescriptors[d++].setBuffer(frameBuffer[(i*2) / mode.vDiv], mode.hRes * bytesPerSample());
+		}
+		for (int i = 0; i < mode.vFront; i++)
+		{
+			dmaBufferDescriptors[d++].setBuffer(normalFrontLineBuffer, bytesHL);
+			dmaBufferDescriptors[d++].setBuffer(normalBackLineBuffer, bytesHL);
+		}
+
+		}
+	}
+
+	virtual void show(bool vSync = false)
+	{
+		if (!frameBufferCount)
+			return;
+		if (vSync)
+		{
+			//TODO read the I2S docs to find out
+		}
+		Graphics::show(vSync);
+		//if(dmaBufferDescriptors)
+		//for (int i = 0; i < yres * mode.vDiv; i++)
+			//dmaBufferDescriptors[(mode.vFront + mode.vSync + mode.vBack + i) * 2 + 1].setBuffer(frontBuffer[i / mode.vDiv], mode.hRes * bytesPerSample());
+	}
+
+	virtual void scroll(int dy, Color color)
+	{
+		Graphics::scroll(dy, color);
+		if (frameBufferCount == 1)
+			show();
+	}
+
+  protected:
+	virtual void interrupt()
+	{
+	}
+};

--- a/src/ESP32Lib.h
+++ b/src/ESP32Lib.h
@@ -8,6 +8,8 @@
 #include <VGA/VGA3Bit.h>
 #include <Composite/CompositeL8.h>
 #include <Composite/CompositePAL8.h>
+#include <Composite/CompositeGrayDAC.h>
+#include <Composite/CompositeGrayLadder.h>
 
 #include <LED/SerialLED.h>
 

--- a/src/ESP32Lib.h
+++ b/src/ESP32Lib.h
@@ -10,6 +10,8 @@
 #include <Composite/CompositePAL8.h>
 #include <Composite/CompositeGrayDAC.h>
 #include <Composite/CompositeGrayLadder.h>
+#include <Composite/CompositeColorDAC.h>
+#include <Composite/CompositeColorLadder.h>
 
 #include <LED/SerialLED.h>
 

--- a/src/Graphics/GraphicsCA8Swapped.h
+++ b/src/Graphics/GraphicsCA8Swapped.h
@@ -1,0 +1,124 @@
+/*
+	Author: bitluni 2019
+	License: 
+	Creative Commons Attribution ShareAlike 4.0
+	https://creativecommons.org/licenses/by-sa/4.0/
+	
+	For further details check out: 
+		https://youtube.com/bitlunislab
+		https://github.com/bitluni
+		http://bitluni.net
+*/
+#pragma once
+#include "Graphics.h"
+
+class GraphicsCA8Swapped: public Graphics<unsigned char>
+{
+	public:
+	typedef unsigned char Color;
+
+	int levelHighClipping = 255;
+	int levelWhite = 207;
+	int amplitudeBurst = 31;
+	int levelBlack = 62;
+	int levelBlanking = 62;
+	int levelLowClipping = 14;
+	int levelSync = 0;
+
+	int firstPixelOffset = 0; // falling edge of hSync
+	double colorClockPeriod = 1; // in pixels
+	int bufferVDiv = 1;
+	bool bufferInterlaced = false;
+	bool bufferPhaseAlternating = false;
+
+	GraphicsCA8Swapped()
+	{
+		frontColor = 0xff;
+	}
+
+	virtual int R(Color c) const
+	{
+		return (((int)c & 3) * 255 + 1) / 3;
+	}
+	virtual int G(Color c) const
+	{
+		return (((int)(c >> 2) & 3) * 255 + 1) / 3;
+	}
+	virtual int B(Color c) const
+	{
+		return (((int)(c >> 4) & 3) * 255 + 1) / 3;
+	}
+	virtual int A(Color c) const
+	{
+		return (((int)(c >> 6) & 3) * 255 + 1) / 3;
+	}
+
+	virtual Color RGBA(int r, int g, int b, int a = 255) const
+	{
+		return ((r >> 6) & 0b11) | ((g >> 4) & 0b1100) | ((b >> 2) & 0b110000) | (a & 0b11000000);
+	}
+
+	virtual void dotFast(int x, int y, Color color)
+	{
+		int r = R(color);
+		int g = G(color);
+		int b = B(color);
+		
+		float Y = 0.299*r + 0.587*g + 0.114*b; // range 0,255
+		float B_Y = b - Y;// range +/- 225.93
+		float R_Y = r - Y;// range +/- 178.755
+		double phase = ((double)(x + firstPixelOffset)/colorClockPeriod)*(2*PI);
+		float signal = 0;
+		if(bufferPhaseAlternating)
+		{
+			//signal = Y + 0.492111*B_Y*sin(phase) + ((y&1==0)?1:-1)*0.877283*R_Y*cos(phase);
+			//PENDING: DEBUG SOME ERROR: I NEEDED TO SWAP R_Y AND B_Y AND TO ADD 1/3*PI TO PHASE
+			//TO GET COLORS IN ORDER (THEY APPEARED BGR AFTER BURST PHASE ADJUSTMENT)
+			//THIS WORKS ON CRT TVs BUT NOT IN LCD
+			signal = Y + 0.492111*R_Y*sin(phase + PI*1/3) + ((y&1==0)?1:-1)*0.877283*B_Y*cos(phase + PI*1/3);
+		} else {
+			signal = 0.925*Y + 0.075*255 + 0.925*0.492111*B_Y*sin(phase) + 0.925*0.877283*R_Y*cos(phase);
+		}
+		signal = levelBlanking + signal * (levelWhite - levelBlanking + 1) / 256;
+		if (signal > levelHighClipping) signal = levelHighClipping;
+		if (signal < levelLowClipping) signal = levelLowClipping;
+		backBuffer[y][x^2] = ((uint8_t)signal);
+	}
+
+	virtual void dot(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			dotFast(x, y, color);
+	}
+
+	virtual void dotAdd(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			dotFast(x, y, color);
+	}
+	
+	virtual void dotMix(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			dotFast(x, y, color);
+	}
+	
+	virtual Color get(int x, int y)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			return backBuffer[y][x^2];
+		return 0;
+	}
+
+	virtual void clear(Color color = 0)
+	{
+		for (int y = 0; y < this->yres; y++)
+			for (int x = 0; x < this->xres; x++)
+				dotFast(x, y, color);
+	}
+
+	virtual Color** allocateFrameBuffer()
+	{
+		return Graphics<Color>::allocateFrameBuffer(xres, yres, 0);
+	}
+};

--- a/src/Graphics/GraphicsW8RangedSwapped.h
+++ b/src/Graphics/GraphicsW8RangedSwapped.h
@@ -1,0 +1,96 @@
+/*
+	Author: bitluni 2019
+	License: 
+	Creative Commons Attribution ShareAlike 4.0
+	https://creativecommons.org/licenses/by-sa/4.0/
+	
+	For further details check out: 
+		https://youtube.com/bitlunislab
+		https://github.com/bitluni
+		http://bitluni.net
+*/
+#pragma once
+#include "Graphics.h"
+
+class GraphicsW8RangedSwapped: public Graphics<unsigned char>
+{
+	public:
+	typedef unsigned char Color;
+	int colorDepthConversionFactor = 256;
+	int colorMinValue = 0;
+	int colorMaxValue = 255;
+
+	GraphicsW8RangedSwapped()
+	{
+		frontColor = 0xff;
+	}
+
+	virtual int R(Color c) const
+	{
+		return c;
+	}
+	virtual int G(Color c) const
+	{
+		return c;
+	}
+	virtual int B(Color c) const
+	{
+		return c;
+	}
+	virtual int A(Color c) const
+	{
+		return 255;
+	}
+
+	virtual Color RGBA(int r, int g, int b, int a = 255) const
+	{
+		return (r * 2126 + g * 7152 + b * 722) * colorDepthConversionFactor / 256 / 10000;
+	}
+
+	virtual void dotFast(int x, int y, Color color)
+	{
+		backBuffer[y][x^2] = ((colorMinValue<<8) + colorDepthConversionFactor*(int)color)>>8;
+	}
+
+	virtual void dot(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			dotFast(x, y, color);
+	}
+
+	virtual void dotAdd(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+		{
+			int newColor = get(x, y);
+			newColor += color;
+			dotFast(x, y, (newColor > 0xff) ? 0xff : newColor);
+		}
+	}
+	
+	virtual void dotMix(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres && (color > 0))
+			dotFast(x, y, ((int)get(x, y) + color)>>1);
+	}
+	
+	virtual Color get(int x, int y)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			return (Color)((((int)backBuffer[y][x^2] << 8) - (colorMinValue<<8)) / colorDepthConversionFactor);
+		return 0;
+	}
+
+	virtual void clear(Color color = 0)
+	{
+		Color newColor = ((colorMinValue<<8) + colorDepthConversionFactor*(int)color)>>8;
+		for (int y = 0; y < this->yres; y++)
+			for (int x = 0; x < this->xres; x++)
+				backBuffer[y][x^2] = newColor;
+	}
+
+	virtual Color** allocateFrameBuffer()
+	{
+		return Graphics<Color>::allocateFrameBuffer(xres, yres, (Color)colorMinValue);
+	}
+};

--- a/src/Graphics/GraphicsX6S2W8Swapped.h
+++ b/src/Graphics/GraphicsX6S2W8Swapped.h
@@ -1,0 +1,100 @@
+/*
+	Author: bitluni 2019
+	License: 
+	Creative Commons Attribution ShareAlike 4.0
+	https://creativecommons.org/licenses/by-sa/4.0/
+	
+	For further details check out: 
+		https://youtube.com/bitlunislab
+		https://github.com/bitluni
+		http://bitluni.net
+*/
+#pragma once
+#include "Graphics.h"
+
+class GraphicsX6S2W8Swapped: public Graphics<unsigned short>
+{
+	public:
+	typedef unsigned short Color;
+	static const Color RGBAXMask = 0xff3f;
+	Color SBits;
+	int colorDepthConversionFactor = 256;
+	int colorMinValue = 0;
+	int colorMaxValue = 255;
+
+
+	GraphicsX6S2W8Swapped()
+	{
+		SBits = 0xc0;
+		frontColor = 0xff00;
+	}
+
+	virtual int R(Color c) const
+	{
+		return c >> 8;
+	}
+	virtual int G(Color c) const
+	{
+		return c >> 8;
+	}
+	virtual int B(Color c) const
+	{
+		return c >> 8;
+	}
+	virtual int A(Color c) const
+	{
+		return 255;
+	}
+
+	virtual Color RGBA(int r, int g, int b, int a = 255) const
+	{
+		return (r * 2126 + g * 7152 + b * 722) / 10000;
+	}
+
+	virtual void dotFast(int x, int y, Color color)
+	{
+		backBuffer[y][x^1] = ((((colorMinValue<<8) + colorDepthConversionFactor*(int)color) & 0xFF00) & RGBAXMask) | SBits;
+	}
+
+	virtual void dot(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			dotFast(x, y, color);
+	}
+
+	virtual void dotAdd(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+		{
+			int newColor = get(x, y);
+			newColor += color;
+			dotFast(x, y, (newColor > 0xff) ? 0xff : newColor);
+		}
+	}
+	
+	virtual void dotMix(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres && (color > 0))
+			dotFast(x, y, ((int)get(x, y) + color)>>1);
+	}
+	
+	virtual Color get(int x, int y)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			return (((backBuffer[y][x^1] & RGBAXMask) & 0xFF00) - (colorMinValue<<8)) / colorDepthConversionFactor;
+		return 0;
+	}
+
+	virtual void clear(Color color = 0)
+	{
+		Color newColor = ((((colorMinValue<<8) + colorDepthConversionFactor*(int)color) & 0xFF00) & RGBAXMask) | SBits;
+		for (int y = 0; y < this->yres; y++)
+			for (int x = 0; x < this->xres; x++)
+				this->backBuffer[y][x] = newColor;
+	}
+
+	virtual Color** allocateFrameBuffer()
+	{
+		return Graphics<Color>::allocateFrameBuffer(xres, yres, (Color)SBits);
+	}
+};

--- a/src/Graphics/GraphicsX8CA8Swapped.h
+++ b/src/Graphics/GraphicsX8CA8Swapped.h
@@ -1,0 +1,126 @@
+/*
+	Author: bitluni 2019
+	License: 
+	Creative Commons Attribution ShareAlike 4.0
+	https://creativecommons.org/licenses/by-sa/4.0/
+	
+	For further details check out: 
+		https://youtube.com/bitlunislab
+		https://github.com/bitluni
+		http://bitluni.net
+*/
+#pragma once
+#include "Graphics.h"
+
+class GraphicsX8CA8Swapped: public Graphics<unsigned short>
+{
+	public:
+	typedef unsigned short Color;
+
+	int levelHighClipping = 95;
+	int levelWhite = 77;
+	int amplitudeBurst = 11;
+	int levelBlack = 23;
+	int levelBlanking = 23;
+	int levelLowClipping = 5;
+	int levelSync = 0;
+
+	int firstPixelOffset = 0; // falling edge of hSync
+	double colorClockPeriod = 1; // in pixels
+	int bufferVDiv = 1;
+	bool bufferInterlaced = false;
+	bool bufferPhaseAlternating = false;
+
+
+
+	GraphicsX8CA8Swapped()
+	{
+		frontColor = 0xffff;
+	}
+
+	virtual int R(Color c) const
+	{
+		return (((c << 1) & 0x3e) * 255 + 1) / 0x3e;
+	}
+	virtual int G(Color c) const
+	{
+		return (((c >> 4) & 0x3e) * 255 + 1) / 0x3e;
+	}
+	virtual int B(Color c) const
+	{
+		return (((c >> 9) & 0x1e) * 255 + 1) / 0x1e;
+	}
+	virtual int A(Color c) const
+	{
+		return (((c >> 13) & 6) * 255 + 1) / 6;
+	}
+
+	virtual Color RGBA(int r, int g, int b, int a = 255) const
+	{
+		return ((r >> 3) & 0b11111) | ((g << 2) & 0b1111100000) | ((b << 6) & 0b11110000000000) | ((a << 8) & 0xc000);
+	}
+
+	virtual void dotFast(int x, int y, Color color)
+	{
+		int r = R(color);
+		int g = G(color);
+		int b = B(color);
+		
+		float Y = 0.299*r + 0.587*g + 0.114*b; // range 0,255
+		float B_Y = b - Y;// range +/- 225.93
+		float R_Y = r - Y;// range +/- 178.755
+		double phase = ((double)(x + firstPixelOffset)/colorClockPeriod)*(2*PI);
+		float signal = 0;
+		if(bufferPhaseAlternating)
+		{
+			//signal = Y + 0.492111*B_Y*sin(phase) + ((y&1==0)?1:-1)*0.877283*R_Y*cos(phase);
+			//PENDING: DEBUG SOME ERROR: I NEEDED TO SWAP R_Y AND B_Y AND TO ADD 1/3*PI TO PHASE
+			//TO GET COLORS IN ORDER (THEY APPEARED BGR AFTER BURST PHASE ADJUSTMENT)
+			//THIS WORKS ON CRT TVs BUT NOT IN LCD
+			signal = Y + 0.492111*R_Y*sin(phase + PI*1/3) + ((y&1==0)?1:-1)*0.877283*B_Y*cos(phase + PI*1/3);
+		} else {
+			signal = 0.925*Y + 0.075*255 + 0.925*0.492111*B_Y*sin(phase) + 0.925*0.877283*R_Y*cos(phase);
+		}
+		signal = levelBlanking + signal * (levelWhite - levelBlanking + 1) / 256;
+		if (signal > levelHighClipping) signal = levelHighClipping;
+		if (signal < levelLowClipping) signal = levelLowClipping;
+		backBuffer[y][x^1] = ((uint8_t)signal) << 8;
+	}
+
+	virtual void dot(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			dotFast(x, y, color);
+	}
+
+	virtual void dotAdd(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			dotFast(x, y, color);
+	}
+	
+	virtual void dotMix(int x, int y, Color color)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			dotFast(x, y, color);
+	}
+	
+	virtual Color get(int x, int y)
+	{
+		if ((unsigned int)x < xres && (unsigned int)y < yres)
+			return backBuffer[y][x^1];
+		return 0;
+	}
+
+	virtual void clear(Color color = 0)
+	{
+		for (int y = 0; y < this->yres; y++)
+			for (int x = 0; x < this->xres; x++)
+				dotFast(x, y, color);
+	}
+
+	virtual Color** allocateFrameBuffer()
+	{
+		return Graphics<Color>::allocateFrameBuffer(xres, yres, 0);
+	}
+};


### PR DESCRIPTION
This allows grayscale output through the internal DAC (only one connection, from pin 25 or 26). It includes definitions for PAL or NTSC, combined with fake progressive low resolution or with interlaced high resolution (be careful with memory requirements for the DAC option there, interlaced may exceed that availabe).
I needed to improve the container "ModeComposite" to describe signals in more detail, which makes the container incompatible with current definitions (and probably with previous composite modes). However, I created the equivalent to "CompositeL8.h" which is "CompositeGrayLadder.h" and should work as a drop-in replacement. I could not test it with you boards (because I do not have them), but it worked with a "toy" resistor ladder that I built. I would be glad to hear if you could test them with your boards.
Fixes #42 