### PR TITLE
println to handle screen scrolling

### DIFF
--- a/src/Graphics/Graphics.h
+++ b/src/Graphics/Graphics.h
@@ -190,6 +190,8 @@ class Graphics: public ImageDrawer
 			{
 				cursorX = cursorBaseX;
 				cursorY += font->charHeight;
+				if(autoScroll && cursorY + font->charHeight > yres)
+					scroll(cursorY + font->charHeight - yres, backColor);
 			}
 			else
 				print(*str);
@@ -199,7 +201,7 @@ class Graphics: public ImageDrawer
 
 	void println(const char *str)
 	{
-		print(str); 
+		print(str);
 		print("\n");
 	}
 


### PR DESCRIPTION
This PR addresses an issue where the `println` method did not correctly handle line breaks and screen scrolling. When using `print`, the text would successfully scroll down to a new line as expected. However, `println` would not scroll down to a new line, causing text to be printed below the visible display area.

This PR resolves issue #89 