### PR TITLE
fix compilation error with later 3.0.x versions of arduino-esp32

### DIFF
--- a/src/I2S/DMABufferDescriptor.h
+++ b/src/I2S/DMABufferDescriptor.h
@@ -105,7 +105,7 @@ class DMABufferDescriptor : protected lldesc_t
 		if (!b)
 			DEBUG_PRINTLN("Failed to alloc DMABufferDescriptor");
 		b->init();
-		if (allocateBuffer)
+		if (allocBuffer)
 			b->setBuffer(allocateBuffer(bytes, clear, clearValue), bytes);
 		return b;
 	}

--- a/src/VGA/VGA.h
+++ b/src/VGA/VGA.h
@@ -33,7 +33,7 @@ class VGA : public VGAMode, public VGAPinConfig
 
 	// TODO This function should be pure virtual, but it is currently implemented with added arguments in children classes
 	virtual bool init(const Mode &mode, const int *pinMap, const int bitCount, const int clockPin = -1)
-	{}
+	{ return false; }
 
 	virtual bool init(const Mode &mode, const PinConfig &pinConfig) = 0;
 


### PR DESCRIPTION
This fixes a compilation error in ```VGA.h```:

```
/home/steve/Arduino/libraries/ESP32Lib/src/VGA/VGA.h: In member function 'virtual bool VGA::init(const Mode&, const int*, int, int)':
/home/steve/Arduino/libraries/ESP32Lib/src/VGA/VGA.h:36:10: error: no return statement in function returning non-void [-Werror=return-type]
   36 |         {}
```

It looks as if this became an error sometime between version 3.0.3 and 3.0.7.

I'm also getting a lot of compiler warnings. I can have a go at fixing these as well if you'd like?

Cheers,
Steve